### PR TITLE
Fix timetables with zero groups

### DIFF
--- a/frontend/src/components/Timetable.js
+++ b/frontend/src/components/Timetable.js
@@ -91,7 +91,7 @@ export default class Timetable extends React.Component {
     settings.timeStep = 15 * 60 * 1000;
     settings.timeSpan = Math.ceil(hour / (15 * 60 * 1000));
     settings.groups = [...groups].sort(byOrder);
-    settings.groupCnt = groups.length;
+    settings.groupCnt = groups.length > 0 ? groups.length : 1;
 
     return settings;
   }


### PR DESCRIPTION
When calculating the Y position of a program, the day is multiplied by the number of groups. So the group count cannot be zero.