### PR TITLE
Fix CSS error in Bootstrap

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -239,3 +239,8 @@ p.program-violations {
     display: none;
   }
 }
+
+/* Bootstrap fix */
+.nav-pills .nav-link.btn-dark {
+  background: 0 0 #343a40;
+}


### PR DESCRIPTION
The `btn-dark` was not working on a button inside a navbar.