### PR TITLE
Prevent destructive changes when managing users

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -420,18 +420,16 @@ export default class App extends React.Component {
                     )
                   }
                   deletePkg={(id) =>
-                    this.state.client
-                      .deletePackage(id)
-                      .then(
-                        (msg) =>
-                          this.setState(
-                            {
-                              pkgs: this.state.pkgs.filter((p) => p._id !== id),
-                            },
-                            this.runChecker
-                          ),
-                        this.handleError
-                      )
+                    this.state.client.deletePackage(id).then(
+                      (msg) =>
+                        this.setState(
+                          {
+                            pkgs: this.state.pkgs.filter((p) => p._id !== id),
+                          },
+                          this.runChecker
+                        ),
+                      this.handleError
+                    )
                   }
                 />
               </Tab.Pane>
@@ -541,6 +539,9 @@ export default class App extends React.Component {
               <Tab.Pane eventKey="users" title="Uživatelé">
                 <Users
                   users={this.state.users}
+                  userEmail={
+                    this.auth.currentUser ? this.auth.currentUser.email : null
+                  }
                   addUser={(user) =>
                     this.state.client.addUser(user).then(
                       (user) =>


### PR DESCRIPTION
The changes are only on frontend, since we are protecting users from themselves. The following flow is considered:

1. new timetable is created, there is implicit public user with ADMIN access
2. the user is instructed to sign in
3. after sign in, the user is instructed to grant themselves ADMIN rights
4. only then the user can change the public access
5. after changing public access below ADMIN, the user cannot remove ADMIN rights from themselves without adding another user
6. after adding another admin, the user can change their access level and they see a warning that by doing so, they will lose access