### PR TITLE
Fix overlap logic for blocks

### DIFF
--- a/frontend/src/components/Timetable.js
+++ b/frontend/src/components/Timetable.js
@@ -109,7 +109,9 @@ function groupProgramsToBlocks(unsortedPrograms) {
   const blocks = [];
 
   const overlaps = (a, b) =>
-    a.filter((i1) => b.find((i2) => i1 === i2)).length > 0;
+    a.filter((i1) => b.find((i2) => i1 === i2)).length > 0 ||
+    a.length === 0 ||
+    b.length === 0;
 
   for (let i = 0; i < programs.length; i++) {
     if (alreadyInBlock[i]) continue;


### PR DESCRIPTION
It was broken in case there was no group assigned to a program.