### PR TITLE
Remove droppable margin

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -241,7 +241,6 @@ p {
 }
 
 .droppable {
-  margin: 2px;
   border-radius: 4px;
 }
 .droppable:hover {


### PR DESCRIPTION
The margin caused problems when dragging - there were spots where a program could not be dropped.