### PR TITLE
Implement better timetable layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 Scout planner is a single-page app that helps with planning scout events.
 
 You can try it at https://harmac.cz
+
+## Running locally for development
+1) Setup Firestore emulator (see [instructions](https://cloud.google.com/firestore/docs/emulator)) and start it: `gcloud emulators firestore start --host-port 127.0.0.1:8080`.
+2) Save the Firestore emulator host to `.env.local` file - create `.env.local` file with the following content:
+```
+FIRESTORE_EMULATOR_HOST="127.0.0.1:8080"
+```
+3) Create `src/config.local.json` file with the following content:
+```json
+{}
+```
+4) Install dependencies using `npm ci` command.
+5) Run the app using `npm start` command.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,11 @@ export default [
   ),
   ...tseslint.configs.recommended,
   {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
+  {
     plugins: {
       react,
       cypress,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "scout-planner",
       "version": "0.1.0",
       "dependencies": {
+        "@js-temporal/polyfill": "^0.4.4",
         "@reduxjs/toolkit": "^2.3.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.1",
@@ -1591,18 +1592,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -1617,6 +1606,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+      "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+      "dependencies": {
+        "jsbi": "^4.3.0",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2041,9 +2042,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
-      "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -2135,9 +2136,9 @@
       }
     },
     "node_modules/@types/aria-query": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "peer": true
     },
     "node_modules/@types/babel__core": {
@@ -2206,17 +2207,6 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2241,16 +2231,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -3128,14 +3108,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -5482,6 +5454,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -6985,17 +6962,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7003,18 +6969,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/sshpk": {
@@ -7227,34 +7181,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
-    },
-    "node_modules/terser": {
-      "version": "5.16.5",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
-      "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -9112,18 +9038,6 @@
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true
     },
-    "@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -9138,6 +9052,15 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@js-temporal/polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.4.tgz",
+      "integrity": "sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==",
+      "requires": {
+        "jsbi": "^4.3.0",
+        "tslib": "^2.4.1"
       }
     },
     "@nodelib/fs.scandir": {
@@ -9425,9 +9348,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
-      "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "peer": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -9486,9 +9409,9 @@
       "requires": {}
     },
     "@types/aria-query": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "peer": true
     },
     "@types/babel__core": {
@@ -9557,17 +9480,6 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
-    "@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -9592,16 +9504,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-dom": {
-      "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@types/react": "*"
       }
     },
     "@types/react-transition-group": {
@@ -10176,14 +10078,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "cac": {
       "version": "6.7.14",
@@ -11885,6 +11779,11 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -12959,31 +12858,11 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
     },
     "sshpk": {
       "version": "1.18.0",
@@ -13141,30 +13020,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
-    },
-    "terser": {
-      "version": "5.16.5",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
-      "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
-      }
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^2.3.0",
+    "@js-temporal/polyfill": "^0.4.4",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -243,11 +243,10 @@ export function TimetableWrapper({
   printView = false,
 }) {
   const { table } = useSelector((state) => state.auth);
-  const { data: settings, isSuccess: settingsLoaded } =
-    useGetSettingsQuery(table);
-  const timetableLayoutVersion = settings?.timetableLayoutVersion;
+  const { data: timetableData, isSuccess: settingsLoaded } =
+    useGetTimetableQuery(table);
   const TimetableComponent =
-    timetableLayoutVersion === "v1" ? Timetable : TimetableV2;
+    timetableData?.layoutVersion === "v1" ? Timetable : TimetableV2;
 
   if (!settingsLoaded || !permissionsLoaded || !dataLoaded) {
     return (

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AddProgramModal, EditProgramModal } from "./EditProgramModal";
 import Timetable from "./Timetable";
+import TimetableV2 from "./TimetableV2";
 import Packages from "./Packages";
 import Groups from "./Groups";
 import People from "./People";
@@ -241,20 +242,28 @@ export function TimetableWrapper({
   permissionsLoaded,
   printView = false,
 }) {
+  const { table } = useSelector((state) => state.auth);
+  const { data: settings, isSuccess: settingsLoaded } = useGetSettingsQuery(table);
+  const timetableLayoutVersion = settings?.timetableLayoutVersion;
+  const TimetableComponent = timetableLayoutVersion === "v1" ? Timetable : TimetableV2;
+
+  if (!settingsLoaded || !permissionsLoaded || !dataLoaded) {
+    return (
+      <Container fluid>
+        <Alert variant="primary">
+          <i className="fa fa-spinner fa-pulse" />
+          &nbsp; Načítání&hellip;
+        </Alert>
+      </Container>
+    );
+  }
+
   return (
     <>
-      {userLevel >= level.VIEW && dataLoaded && permissionsLoaded && (
-        <Timetable violations={violationsPerProgram} printView={printView} />
+      {userLevel >= level.VIEW && (
+        <TimetableComponent violations={violationsPerProgram} printView={printView} />
       )}
-      {(!dataLoaded || !permissionsLoaded) && (
-        <Container fluid>
-          <Alert variant="primary">
-            <i className="fa fa-spinner fa-pulse" />
-            &nbsp; Načítání&hellip;
-          </Alert>
-        </Container>
-      )}
-      {userLevel === level.NONE && dataLoaded && permissionsLoaded && (
+      {userLevel === level.NONE && (
         <Container fluid>
           <Alert variant="danger">
             <i className="fa fa-exclamation-triangle" />

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -243,9 +243,11 @@ export function TimetableWrapper({
   printView = false,
 }) {
   const { table } = useSelector((state) => state.auth);
-  const { data: settings, isSuccess: settingsLoaded } = useGetSettingsQuery(table);
+  const { data: settings, isSuccess: settingsLoaded } =
+    useGetSettingsQuery(table);
   const timetableLayoutVersion = settings?.timetableLayoutVersion;
-  const TimetableComponent = timetableLayoutVersion === "v1" ? Timetable : TimetableV2;
+  const TimetableComponent =
+    timetableLayoutVersion === "v1" ? Timetable : TimetableV2;
 
   if (!settingsLoaded || !permissionsLoaded || !dataLoaded) {
     return (
@@ -261,7 +263,10 @@ export function TimetableWrapper({
   return (
     <>
       {userLevel >= level.VIEW && (
-        <TimetableComponent violations={violationsPerProgram} printView={printView} />
+        <TimetableComponent
+          violations={violationsPerProgram}
+          printView={printView}
+        />
       )}
       {userLevel === level.NONE && (
         <Container fluid>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -28,7 +28,6 @@ import { useGetProgramsQuery } from "../store/programsApi";
 
 export default function Settings() {
   const userLevel = useSelector((state) => state.auth.userLevel);
-  const timetableTitle = useSelector((state) => state.config.timetableTitle);
   const { table } = useSelector((state) => state.auth);
   const { data: settings, isSuccess: settingsLoaded } =
     useGetSettingsQuery(table);

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -29,12 +29,20 @@ import {
   useGetTimetableQuery,
   useUpdateLayoutVersionMutation,
 } from "../store/timetableApi";
+import configLocal from "../config.local.json";
+import config from "../config.json";
+
+const timetableLayoutVersionSwitchingEnabled =
+  { ...config, ...configLocal }.timetableLayoutVersionSwitchingEnabled ?? false;
 
 export default function Settings() {
   const userLevel = useSelector((state) => state.auth.userLevel);
   const { table } = useSelector((state) => state.auth);
-  const { data: timetableData, isSuccess: layoutVersionLoaded } = useGetTimetableQuery(table);
-  const layoutVersion = layoutVersionLoaded ? timetableData.layoutVersion : null;
+  const { data: timetableData, isSuccess: layoutVersionLoaded } =
+    useGetTimetableQuery(table);
+  const layoutVersion = layoutVersionLoaded
+    ? timetableData.layoutVersion
+    : null;
 
   if (!layoutVersionLoaded) {
     return null;
@@ -51,7 +59,9 @@ export default function Settings() {
             {userLevel >= level.EDIT && <Width />}
           </>
         )}
-        {userLevel >= level.EDIT && <TimetableLayoutVersion />}
+        {userLevel >= level.EDIT && timetableLayoutVersionSwitchingEnabled && (
+          <TimetableLayoutVersion />
+        )}
         <h2 className="mt-5 text-danger">
           <i className="fa fa-exclamation-triangle"></i> Pokročilé
         </h2>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -25,15 +25,18 @@ import {
   useUpdateSettingsMutation,
 } from "../store/settingsApi";
 import { useGetProgramsQuery } from "../store/programsApi";
+import {
+  useGetTimetableQuery,
+  useUpdateLayoutVersionMutation,
+} from "../store/timetableApi";
 
 export default function Settings() {
   const userLevel = useSelector((state) => state.auth.userLevel);
   const { table } = useSelector((state) => state.auth);
-  const { data: settings, isSuccess: settingsLoaded } =
-    useGetSettingsQuery(table);
-  const timetableLayoutVersion = settings.timetableLayoutVersion;
+  const { data: timetableData, isSuccess: layoutVersionLoaded } = useGetTimetableQuery(table);
+  const layoutVersion = layoutVersionLoaded ? timetableData.layoutVersion : null;
 
-  if (!settingsLoaded) {
+  if (!layoutVersionLoaded) {
     return null;
   }
 
@@ -42,7 +45,7 @@ export default function Settings() {
       <Container fluid>
         <h2 className="mt-3">Nastavení</h2>
         {userLevel >= level.EDIT && <TimetableTitle />}
-        {timetableLayoutVersion === "v1" && (
+        {layoutVersion === "v1" && (
           <>
             {userLevel >= level.EDIT && <TimeStep />}
             {userLevel >= level.EDIT && <Width />}
@@ -229,12 +232,11 @@ const timetableLayoutVersions = [
 
 function TimetableLayoutVersion() {
   const { table } = useSelector((state) => state.auth);
-  const { data: settings, isSuccess: settingsLoaded } =
-    useGetSettingsQuery(table);
-  const [updateSettings] = useUpdateSettingsMutation();
+  const { data, isSuccess: queryLoaded } = useGetTimetableQuery(table);
+  const [updateVersion] = useUpdateLayoutVersionMutation();
 
   const [version, setVersion] = useState(
-    settingsLoaded ? settings.timetableLayoutVersion : "v1",
+    queryLoaded ? data.layoutVersion : "v1",
   );
   const [editing, setEditing] = useState(false);
 
@@ -242,9 +244,9 @@ function TimetableLayoutVersion() {
     event.preventDefault();
 
     if (editing) {
-      updateSettings({
+      updateVersion({
         table,
-        data: { ...settings, timetableLayoutVersion: version },
+        data: version,
       });
       setEditing(false);
     } else {
@@ -272,7 +274,7 @@ function TimetableLayoutVersion() {
             </Form.Select>
           ) : (
             <Form.Label className="pt-2">
-              {settingsLoaded &&
+              {queryLoaded &&
                 timetableLayoutVersions.find((it) => it.key === version)?.label}
             </Form.Label>
           )}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -225,7 +225,7 @@ function Width() {
 const timetableLayoutVersions = [
   { key: "v1", label: "Verze 1 (původní)" },
   { key: "v2", label: "Verze 2 (experimentální)" },
-]
+];
 
 function TimetableLayoutVersion() {
   const { table } = useSelector((state) => state.auth);
@@ -272,7 +272,8 @@ function TimetableLayoutVersion() {
             </Form.Select>
           ) : (
             <Form.Label className="pt-2">
-              {settingsLoaded && timetableLayoutVersions.find((it) => it.key === version)?.label}
+              {settingsLoaded &&
+                timetableLayoutVersions.find((it) => it.key === version)?.label}
             </Form.Label>
           )}
         </Col>

--- a/src/components/TimetableV2.tsx
+++ b/src/components/TimetableV2.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, memo, useCallback, useMemo, useRef, useState } from 'react';
+import React, { Fragment, useCallback, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useGetGroupsQuery } from '../store/groupsApi';
 import { useGetPackagesQuery } from '../store/packagesApi';
@@ -48,24 +48,18 @@ interface Person {
   name: string;
 }
 
-interface Range {
-  _id: string;
-  name: string;
-}
-
 type Violation = { msg: string, program: string, satisied?: boolean };
 type Violations = Map<string, Violation[]>;
 
 export default function Timetable({
   violations,
-  timeProvider = null,
   printView = false,
 }: {
   violations: Violations;
   timeProvider: null | (() => number);
   printView: boolean;
 }) {
-  const { table, userLevel } = useSelector<any, any>((state) => state.auth);
+  const { userLevel } = useSelector<any, any>((state) => state.auth);
   return <ComposeSchedule editable={userLevel >= level.EDIT && !printView} violations={violations} />;
 }
 
@@ -173,128 +167,126 @@ interface SegmentBoxProps {
   violations: Violation[];
 }
 
-const SegmentBox = memo<SegmentBoxProps>(
-  ({ segment, earliestTime, latestTime, isHovering, isDragged = false, setHovering, dayIndex, onDragStart, onDragEnd, onClick, onContextMenu, editable, isHighlighted, violations }) => {
-    const program = segment.plannable
-    const dayLength = earliestTime.until(latestTime)
-    const setStartTime = segment.start ?? earliestTime
-    const startTime = Temporal.PlainTime.compare(setStartTime, earliestTime) < 0 ? earliestTime : setStartTime
-    const startOffset = earliestTime.until(startTime).total({ unit: 'seconds' }) / dayLength.total({ unit: 'seconds' })
-    const setEndTime = segment.end ?? latestTime
-    const endTime = Temporal.PlainTime.compare(setEndTime, latestTime) > 0 ? latestTime : setEndTime
-    const duration = startTime.until(endTime)
-    const relativeDuration = duration.total({ unit: 'seconds' }) / dayLength.total({ unit: 'seconds' })
+function SegmentBox({ segment, earliestTime, latestTime, isHovering, isDragged = false, setHovering, dayIndex, onDragStart, onDragEnd, onClick, onContextMenu, editable, isHighlighted, violations }: SegmentBoxProps) {
+  const program = segment.plannable
+  const dayLength = earliestTime.until(latestTime)
+  const setStartTime = segment.start ?? earliestTime
+  const startTime = Temporal.PlainTime.compare(setStartTime, earliestTime) < 0 ? earliestTime : setStartTime
+  const startOffset = earliestTime.until(startTime).total({ unit: 'seconds' }) / dayLength.total({ unit: 'seconds' })
+  const setEndTime = segment.end ?? latestTime
+  const endTime = Temporal.PlainTime.compare(setEndTime, latestTime) > 0 ? latestTime : setEndTime
+  const duration = startTime.until(endTime)
+  const relativeDuration = duration.total({ unit: 'seconds' }) / dayLength.total({ unit: 'seconds' })
 
-    const [clickWidthRatio, setClickWidthRatio] = useState(0)
+  const [clickWidthRatio, setClickWidthRatio] = useState(0)
 
-    if (dayIndex < 0) {
-      return null
-    }
+  if (dayIndex < 0) {
+    return null
+  }
 
-    const pkgs = usePkgs();
-    const pkg = pkgs.find((pkg) => pkg._id === segment.plannable.pkg);
-    const color = pkg?.color ?? DEFAULT_PROGRAM_COLOR;
-    const isDark = color !== null && isColorDark(color);
-    const people = usePeople();
-    const ownerNames = segment.plannable.people.map((person) => (people.find((p) => p._id === person.person))?.name ?? person.person).join(', ');
-    return (
+  const pkgs = usePkgs();
+  const pkg = pkgs.find((pkg) => pkg._id === segment.plannable.pkg);
+  const color = pkg?.color ?? DEFAULT_PROGRAM_COLOR;
+  const isDark = color !== null && isColorDark(color);
+  const people = usePeople();
+  const ownerNames = segment.plannable.people.map((person) => (people.find((p) => p._id === person.person))?.name ?? person.person).join(', ');
+  return (
+    <div
+      className={[
+        'scheduleTable__plannable',
+        isHovering != null && 'scheduleTable__plannable--hovering',
+        isDragged && 'scheduleTable__plannable--dragged',
+        (segment.start?.equals(startTime)) && 'scheduleTable__plannable--start',
+        (segment.end?.equals(endTime)) && 'scheduleTable__plannable--end',
+        isDark && 'scheduleTable__plannable--dark',
+        isHighlighted && 'scheduleTable__plannable--highlighted',
+        isHighlighted === false && 'scheduleTable__plannable--notHighlighted',
+        violations.length > 0 && 'scheduleTable__plannable--violated',
+      ].filter(Boolean).join(' ')}
+      style={{
+        '--segment-day': dayIndex,
+        '--segment-start': startOffset,
+        '--segment-duration': relativeDuration,
+        '--segment-group-first': segment.atendeeGroups[0],
+        '--segment-groups-count': segment.atendeeGroups.length,
+        '--segment-color': color,
+      } as any}
+
+      onMouseEnter={(e) => setHovering({ clientX: e.clientX, clientY: e.clientY })}
+      onMouseMove={(e) => setHovering({ clientX: e.clientX, clientY: e.clientY })}
+      onMouseLeave={() => setHovering(null)}
+
+      {...(editable ? {
+        draggable: true,
+        onDragStart: (e) => {
+          e.dataTransfer.setData(MIME_TYPE, program._id as string)
+          e.dataTransfer.effectAllowed = "move"
+
+          const canvas = document.createElement("canvas");
+          canvas.width = canvas.height = 0;
+          e.dataTransfer.setDragImage(canvas, 25, 25);
+
+          onDragStart(clickWidthRatio)
+        },
+        onDragEnd: () => {
+          onDragEnd()
+        },
+        onMouseDown: (e) => {
+          if (segment.start !== null && segment.end !== null) {
+            setClickWidthRatio(e.nativeEvent.offsetX / e.currentTarget.offsetWidth)
+          } else {
+            setClickWidthRatio(0)
+          }
+        },
+      } : {})}
+
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+      onContextMenu={onContextMenu ? e => {
+        e.preventDefault()
+        e.stopPropagation()
+        onContextMenu?.(e.clientX, e.clientY)
+      } : undefined}
+    >
       <div
-        className={[
-          'scheduleTable__plannable',
-          isHovering != null && 'scheduleTable__plannable--hovering',
-          isDragged && 'scheduleTable__plannable--dragged',
-          (segment.start?.equals(startTime)) && 'scheduleTable__plannable--start',
-          (segment.end?.equals(endTime)) && 'scheduleTable__plannable--end',
-          isDark && 'scheduleTable__plannable--dark',
-          isHighlighted && 'scheduleTable__plannable--highlighted',
-          isHighlighted === false && 'scheduleTable__plannable--notHighlighted',
-          violations.length > 0 && 'scheduleTable__plannable--violated',
-        ].filter(Boolean).join(' ')}
-        style={{
-          '--segment-day': dayIndex,
-          '--segment-start': startOffset,
-          '--segment-duration': relativeDuration,
-          '--segment-group-first': segment.atendeeGroups[0],
-          '--segment-groups-count': segment.atendeeGroups.length,
-          '--segment-color': color,
-        } as any}
-
-        onMouseEnter={(e) => setHovering({ clientX: e.clientX, clientY: e.clientY })}
-        onMouseMove={(e) => setHovering({ clientX: e.clientX, clientY: e.clientY })}
-        onMouseLeave={() => setHovering(null)}
-
-        {...(editable ? {
-          draggable: true,
-          onDragStart: (e) => {
-            e.dataTransfer.setData(MIME_TYPE, program._id as string)
-            e.dataTransfer.effectAllowed = "move"
-
-            const canvas = document.createElement("canvas");
-            canvas.width = canvas.height = 0;
-            e.dataTransfer.setDragImage(canvas, 25, 25);
-
-            onDragStart(clickWidthRatio)
-          },
-          onDragEnd: () => {
-            onDragEnd()
-          },
-          onMouseDown: (e) => {
-            if (segment.start !== null && segment.end !== null) {
-              setClickWidthRatio(e.nativeEvent.offsetX / e.currentTarget.offsetWidth)
-            } else {
-              setClickWidthRatio(0)
-            }
-          },
-        } : {})}
-
-        onClick={(e) => {
-          e.stopPropagation()
-          onClick()
-        }}
-        onContextMenu={onContextMenu ? e => {
-          e.preventDefault()
-          e.stopPropagation()
-          onContextMenu?.(e.clientX, e.clientY)
-        } : undefined}
+        className="scheduleTable__plannableTitle"
       >
-        <div
-          className="scheduleTable__plannableTitle"
-        >
-          {program.locked && <i className="fa fa-lock me-1" />}
-          {violations.length > 0 && <i className="fa fa-exclamation-triangle me-1" />}
-          {program.title}
-        </div>
-        {ownerNames && <div className="scheduleTable__plannableOwners">{ownerNames}</div>}
-        {(isHovering != null && !isDragged) && (
-          <div
-            className="scheduleTable__plannableExpansion"
-            style={{
-              '--position-x': `${isHovering.clientX}px`,
-              '--position-y': `${isHovering.clientY}px`,
-            } as any}
-          >
-            <div
-              className="scheduleTable__plannableTitle"
-            >
-              {program.title}
-            </div>
-            {violations.length > 0 && (
-              <div className="scheduleTable__plannableOwners">
-                <i className="fa fa-exclamation-triangle me-1" />
-                {violations.map((violation) => violation.msg).join(', ')}
-              </div>
-            )}
-            <div className="scheduleTable__plannableOwners">{pkg?.name ?? "Bez balíčku"}</div>
-            {ownerNames && <div className="scheduleTable__plannableOwners">{ownerNames}</div>}
-            <div className="scheduleTable__plannableOwners">
-              {startTime.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })} - {endTime.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })} ({duration.total({ unit: 'minute' })} min)
-            </div>
-          </div>
-        )}
+        {program.locked && <i className="fa fa-lock me-1" />}
+        {violations.length > 0 && <i className="fa fa-exclamation-triangle me-1" />}
+        {program.title}
       </div>
-    );
-  },
-)
+      {ownerNames && <div className="scheduleTable__plannableOwners">{ownerNames}</div>}
+      {(isHovering != null && !isDragged) && (
+        <div
+          className="scheduleTable__plannableExpansion"
+          style={{
+            '--position-x': `${isHovering.clientX}px`,
+            '--position-y': `${isHovering.clientY}px`,
+          } as any}
+        >
+          <div
+            className="scheduleTable__plannableTitle"
+          >
+            {program.title}
+          </div>
+          {violations.length > 0 && (
+            <div className="scheduleTable__plannableOwners">
+              <i className="fa fa-exclamation-triangle me-1" />
+              {violations.map((violation) => violation.msg).join(', ')}
+            </div>
+          )}
+          <div className="scheduleTable__plannableOwners">{pkg?.name ?? "Bez balíčku"}</div>
+          {ownerNames && <div className="scheduleTable__plannableOwners">{ownerNames}</div>}
+          <div className="scheduleTable__plannableOwners">
+            {startTime.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })} - {endTime.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })} ({duration.total({ unit: 'minute' })} min)
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 interface TimeLabelsProps {
   earliestTime: Temporal.PlainTime;
@@ -302,7 +294,7 @@ interface TimeLabelsProps {
   dayLength: Temporal.Duration;
 }
 
-const TimeLabels = memo<TimeLabelsProps>(({ earliestTime, timeLabels, dayLength }) => {
+function TimeLabels({ earliestTime, timeLabels, dayLength }: TimeLabelsProps) {
   return (
     <>
       <div className="scheduleTable__timeLabels">
@@ -333,14 +325,14 @@ const TimeLabels = memo<TimeLabelsProps>(({ earliestTime, timeLabels, dayLength 
       })}
     </>
   )
-})
+}
 
 interface DataLabelsProps {
   dates: Temporal.PlainDate[];
   virtualGroupShown: boolean;
 }
 
-const DataLabels = memo<DataLabelsProps>(({ dates, virtualGroupShown }) => {
+function DataLabels({ dates, virtualGroupShown }: DataLabelsProps) {
   const groups = useGroups();
   const addGroupOffset = virtualGroupShown ? 1 : 0;
 
@@ -382,7 +374,7 @@ const DataLabels = memo<DataLabelsProps>(({ dates, virtualGroupShown }) => {
       ))}
     </>
   )
-})
+}
 
 interface ComposeScheduleProps {
   editable: boolean;
@@ -708,7 +700,7 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
               dayLength={dayLength}
             />
 
-            {[...segments].map((segment, index) => {
+            {[...segments].map((segment) => {
               return (
                 <SegmentBox
                   key={segment.plannable._id}
@@ -753,7 +745,7 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
                 earliestTime={earliestTime}
                 latestTime={latestTime}
                 isHovering={null}
-                setHovering={isHovering => { }}
+                setHovering={() => {}}
                 dayIndex={dates.findIndex(it => it.equals(segment.date))}
                 onDragStart={(widthRatio) => {
                   setDraggingPlannable({

--- a/src/components/TimetableV2.tsx
+++ b/src/components/TimetableV2.tsx
@@ -1,0 +1,886 @@
+import React, { Fragment, memo, useCallback, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useGetGroupsQuery } from '../store/groupsApi';
+import { useGetPackagesQuery } from '../store/packagesApi';
+import { useGetProgramsQuery, useUpdateProgramMutation, useAddProgramMutation } from '../store/programsApi';
+import { useGetPeopleQuery } from '../store/peopleApi';
+import { Temporal } from "@js-temporal/polyfill";
+import { isColorDark } from "../helpers/isColorDark";
+import { maxTime, minTime } from "../helpers/timeCompare";
+import { level } from '../helpers/Level';
+import { useNavigate } from 'react-router-dom';
+import Button from 'react-bootstrap/Button';
+
+const DEFAULT_PROGRAM_COLOR = '#81d4fa'
+
+interface Program {
+  pkg: string | null;
+  notes: string;
+  begin: number | null; // Null signifies that the program is in tray
+  _id: string;
+  duration: number;
+  locked: boolean;
+  ranges: { [key: string]: "0" | "1" | "2" | "3" };
+  blockOrder: number;
+  people: { person: string }[];
+  title: string;
+  place: string;
+  url: string;
+  groups: string[];
+}
+type ScheduledProgram = Program & { begin: number }
+type UnscheduledProgram = Program & { begin: null }
+
+interface Pkg {
+  _id: string;
+  name: string;
+  color: string;
+}
+
+interface Group {
+  _id: string;
+  order: number;
+  name: string;
+}
+
+interface Person {
+  _id: string;
+  name: string;
+}
+
+interface Range {
+  _id: string;
+  name: string;
+}
+
+type Violation = { msg: string, program: string, satisied?: boolean };
+type Violations = Map<string, Violation[]>;
+
+export default function Timetable({
+  violations,
+  timeProvider = null,
+  printView = false,
+}: {
+  violations: Violations;
+  timeProvider: null | (() => number);
+  printView: boolean;
+}) {
+  const { table, userLevel } = useSelector<any, any>((state) => state.auth);
+  return <ComposeSchedule editable={userLevel >= level.EDIT && !printView} violations={violations} />;
+}
+
+function usePrograms(): Program[] {
+  const { table } = useSelector<any, any>((state) => state.auth);
+  const { data: programs }: { data?: Program[] } = useGetProgramsQuery(table);
+  return programs ?? [];
+}
+
+function useGroups(): Group[] {
+  const { table } = useSelector<any, any>((state) => state.auth);
+  const { data: groups }: { data?: Group[] } = useGetGroupsQuery(table);
+  return [...(groups ?? [])].sort((a, b) => a.order - b.order);
+}
+
+function usePkgs(): Pkg[] {
+  const { table } = useSelector<any, any>((state) => state.auth);
+  const { data: pkgs }: { data?: Pkg[] } = useGetPackagesQuery(table);
+  return pkgs ?? [];
+}
+
+function usePeople(): Person[] {
+  const { table } = useSelector<any, any>((state) => state.auth);
+  const { data: people }: { data?: Person[] } = useGetPeopleQuery(table);
+  return people ?? [];
+}
+
+function useUpdateProgram(): (program: Program) => void {
+  const { table } = useSelector<any, any>((state) => state.auth);
+  const [updateProgramMutation] = useUpdateProgramMutation();
+  return (program: Program) => {
+    updateProgramMutation({ table, data: program });
+  };
+}
+
+type NewProgram = Omit<Program, '_id'> & { _id: any };
+function useAddProgram(): (program: NewProgram) => void {
+  const { table } = useSelector<any, any>((state) => state.auth);
+  const [addProgramMutation] = useAddProgramMutation();
+  return (program: NewProgram) => {
+    delete program._id;
+    addProgramMutation({ table, data: program });
+  };
+}
+
+
+const LOCAL_TIMEZONE = Temporal.TimeZone.from('UTC');
+
+const MIME_TYPE = 'application/prs.plannable'
+
+type Segment = { date: Temporal.PlainDate; plannable: Program; start: Temporal.PlainTime | null; end: Temporal.PlainTime | null; atendeeGroups: number[] }
+
+/**
+ * Groups neighbouring numbers into arrays of consecutive numbers
+ * @param _items Array of numbers
+ * @returns Array of arrays of consecutive numbers
+ * 
+ * @example
+ * groupNeighbours([1, 2, 3, 5, 6, 8, 9, 10])
+ * // => [[1, 2, 3], [5, 6], [8, 9, 10]]
+ */
+function groupNeighbours(_items: number[]): number[][] {
+  const items = [..._items];
+  items.sort()
+  const result: number[][] = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+
+    if (result.length === 0 || result[result.length - 1][result[result.length - 1].length - 1] !== item - 1) {
+      result.push([item]);
+    } else {
+      result[result.length - 1].push(item);
+    }
+  }
+
+  return result;
+}
+
+type HoverStatus = null | {
+  clientX: number,
+  clientY: number,
+}
+
+type HoverStatusExtended = null | {
+  clientX: number,
+  clientY: number,
+  id: string,
+}
+
+interface SegmentBoxProps {
+  segment: Segment;
+  earliestTime: Temporal.PlainTime;
+  latestTime: Temporal.PlainTime;
+  isHovering: HoverStatus;
+  isDragged?: boolean;
+  setHovering: (isHovering: HoverStatus) => void;
+  dayIndex: number;
+  onDragStart: (ratio: number) => void;
+  onDragEnd: () => void;
+  onClick: () => void;
+  onContextMenu?: (x: number, y: number) => void;
+  editable: boolean;
+  isHighlighted: boolean | null;
+  violations: Violation[];
+}
+
+const SegmentBox = memo<SegmentBoxProps>(
+  ({ segment, earliestTime, latestTime, isHovering, isDragged = false, setHovering, dayIndex, onDragStart, onDragEnd, onClick, onContextMenu, editable, isHighlighted, violations }) => {
+    const program = segment.plannable
+    const dayLength = earliestTime.until(latestTime)
+    const setStartTime = segment.start ?? earliestTime
+    const startTime = Temporal.PlainTime.compare(setStartTime, earliestTime) < 0 ? earliestTime : setStartTime
+    const startOffset = earliestTime.until(startTime).total({ unit: 'seconds' }) / dayLength.total({ unit: 'seconds' })
+    const setEndTime = segment.end ?? latestTime
+    const endTime = Temporal.PlainTime.compare(setEndTime, latestTime) > 0 ? latestTime : setEndTime
+    const duration = startTime.until(endTime)
+    const relativeDuration = duration.total({ unit: 'seconds' }) / dayLength.total({ unit: 'seconds' })
+
+    const [clickWidthRatio, setClickWidthRatio] = useState(0)
+
+    if (dayIndex < 0) {
+      return null
+    }
+
+    const pkgs = usePkgs();
+    const pkg = pkgs.find((pkg) => pkg._id === segment.plannable.pkg);
+    const color = pkg?.color ?? DEFAULT_PROGRAM_COLOR;
+    const isDark = color !== null && isColorDark(color);
+    const people = usePeople();
+    const ownerNames = segment.plannable.people.map((person) => (people.find((p) => p._id === person.person))?.name ?? person.person).join(', ');
+    return (
+      <div
+        className={[
+          'scheduleTable__plannable',
+          isHovering != null && 'scheduleTable__plannable--hovering',
+          isDragged && 'scheduleTable__plannable--dragged',
+          (segment.start?.equals(startTime)) && 'scheduleTable__plannable--start',
+          (segment.end?.equals(endTime)) && 'scheduleTable__plannable--end',
+          isDark && 'scheduleTable__plannable--dark',
+          isHighlighted && 'scheduleTable__plannable--highlighted',
+          isHighlighted === false && 'scheduleTable__plannable--notHighlighted',
+          violations.length > 0 && 'scheduleTable__plannable--violated',
+        ].filter(Boolean).join(' ')}
+        style={{
+          '--segment-day': dayIndex,
+          '--segment-start': startOffset,
+          '--segment-duration': relativeDuration,
+          '--segment-group-first': segment.atendeeGroups[0],
+          '--segment-groups-count': segment.atendeeGroups.length,
+          '--segment-color': color,
+        } as any}
+
+        onMouseEnter={(e) => setHovering({ clientX: e.clientX, clientY: e.clientY })}
+        onMouseMove={(e) => setHovering({ clientX: e.clientX, clientY: e.clientY })}
+        onMouseLeave={() => setHovering(null)}
+
+        {...(editable ? {
+          draggable: true,
+          onDragStart: (e) => {
+            e.dataTransfer.setData(MIME_TYPE, program._id as string)
+            e.dataTransfer.effectAllowed = "move"
+
+            const canvas = document.createElement("canvas");
+            canvas.width = canvas.height = 0;
+            e.dataTransfer.setDragImage(canvas, 25, 25);
+
+            onDragStart(clickWidthRatio)
+          },
+          onDragEnd: () => {
+            onDragEnd()
+          },
+          onMouseDown: (e) => {
+            if (segment.start !== null && segment.end !== null) {
+              setClickWidthRatio(e.nativeEvent.offsetX / e.currentTarget.offsetWidth)
+            } else {
+              setClickWidthRatio(0)
+            }
+          },
+        } : {})}
+
+        onClick={(e) => {
+          e.stopPropagation()
+          onClick()
+        }}
+        onContextMenu={onContextMenu ? e => {
+          e.preventDefault()
+          e.stopPropagation()
+          onContextMenu?.(e.clientX, e.clientY)
+        } : undefined}
+      >
+        <div
+          className="scheduleTable__plannableTitle"
+        >
+          {program.locked && <i className="fa fa-lock me-1" />}
+          {violations.length > 0 && <i className="fa fa-exclamation-triangle me-1" />}
+          {program.title}
+        </div>
+        {ownerNames && <div className="scheduleTable__plannableOwners">{ownerNames}</div>}
+        {(isHovering != null && !isDragged) && (
+          <div
+            className="scheduleTable__plannableExpansion"
+            style={{
+              '--position-x': `${isHovering.clientX}px`,
+              '--position-y': `${isHovering.clientY}px`,
+            } as any}
+          >
+            <div
+              className="scheduleTable__plannableTitle"
+            >
+              {program.title}
+            </div>
+            {violations.length > 0 && (
+              <div className="scheduleTable__plannableOwners">
+                <i className="fa fa-exclamation-triangle me-1" />
+                {violations.map((violation) => violation.msg).join(', ')}
+              </div>
+            )}
+            <div className="scheduleTable__plannableOwners">{pkg?.name ?? "Bez balíčku"}</div>
+            {ownerNames && <div className="scheduleTable__plannableOwners">{ownerNames}</div>}
+            <div className="scheduleTable__plannableOwners">
+              {startTime.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })} - {endTime.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })} ({duration.total({ unit: 'minute' })} min)
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+)
+
+interface TimeLabelsProps {
+  earliestTime: Temporal.PlainTime;
+  timeLabels: Temporal.PlainTime[];
+  dayLength: Temporal.Duration;
+}
+
+const TimeLabels = memo<TimeLabelsProps>(({ earliestTime, timeLabels, dayLength }) => {
+  return (
+    <>
+      <div className="scheduleTable__timeLabels">
+        {timeLabels.map((label) => {
+          const startOffset = earliestTime.until(label).total({ unit: 'minutes' }) / dayLength.total({ unit: 'minutes' })
+          return (
+            <div
+              key={label.toString()}
+              className={`scheduleTable__timeLabel`}
+              style={{ '--time': startOffset } as any}
+            >
+              {label.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })}
+            </div>
+          )
+        })}
+      </div>
+
+      {timeLabels.map((label) => {
+        const startOffset = earliestTime.until(label).total({ unit: 'minutes' }) / dayLength.total({ unit: 'minutes' })
+        const isMajor = label.minute === 0
+        return (
+          <div
+            key={label.toString()}
+            className={`scheduleTable__timeLine ${isMajor ? 'scheduleTable__timeLine--major' : ''}`}
+            style={{ '--time': startOffset } as any}
+          />
+        )
+      })}
+    </>
+  )
+})
+
+interface DataLabelsProps {
+  dates: Temporal.PlainDate[];
+  virtualGroupShown: boolean;
+}
+
+const DataLabels = memo<DataLabelsProps>(({ dates, virtualGroupShown }) => {
+  const groups = useGroups();
+  const addGroupOffset = virtualGroupShown ? 1 : 0;
+
+  return (
+    <>
+      {dates.map((date, index) => (
+        <Fragment key={date.toString()}>
+          <div
+            className="scheduleTable__dayLabel"
+            style={{ '--day': index } as any}
+          >
+            {date.toLocaleString('cs-CZ', { day: 'numeric', month: 'narrow', weekday: 'short' })}
+          </div>
+
+          <div
+            className="scheduleTable__day"
+            style={{ '--day': index } as any}
+            data-date={date.toString()}
+          />
+
+          {groups.map((group, groupIndex) => (
+            <div
+              key={group._id}
+              className="scheduleTable__groupLabel"
+              style={{
+                '--group-day': index,
+                '--group-index': groupIndex + addGroupOffset,
+              } as any}
+            >
+              {group.name}
+            </div>
+          ))}
+
+          <div
+            className="scheduleTable__dayLine"
+            style={{ '--day': index } as any}
+          />
+        </Fragment>
+      ))}
+    </>
+  )
+})
+
+interface ComposeScheduleProps {
+  editable: boolean;
+  violations: Violations;
+}
+
+export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) => {
+  const [widthScale, setWidthScale] = useState(1)
+
+  // Programs
+  const programs = usePrograms()
+  const scheduledPlannables = useMemo(() => {
+    return programs.filter((it): it is ScheduledProgram => it.begin !== null)
+  }, [programs])
+  const notScheduledPlannables = useMemo(() => {
+    return programs.filter((it): it is UnscheduledProgram => it.begin === null)
+  }, [programs])
+
+  // Context menu
+  const [contextMenu, setContextMenu] = useState<null | { x: number, y: number, id: string }>(null)
+  const contextMenuProgram = useMemo(() => {
+    return programs.find(it => it._id === contextMenu?.id)
+  }, [programs, contextMenu])
+
+  // All dates of the schedule
+  const dates = useMemo(() => {
+    const scheduledDateTimes = scheduledPlannables
+      .map((program): [Temporal.PlainDateTime, Temporal.Duration] => [
+        Temporal.Instant.fromEpochMilliseconds(program.begin).toZonedDateTimeISO(LOCAL_TIMEZONE).toPlainDateTime(),
+        Temporal.Duration.from({ milliseconds: program.duration }),
+      ])
+
+    // Find the first and last date of the schedule
+    let [firstDate, lastDate] = scheduledDateTimes.reduce<[Temporal.PlainDate | null, Temporal.PlainDate | null]>(([firstDate, lastDate], [start, duration]) => {
+      const startPlain = start.toPlainDate()
+      const endPlain = start.add(duration).toPlainDate()
+      return [
+        firstDate === null || Temporal.PlainDate.compare(startPlain, firstDate) < 0 ? startPlain : firstDate,
+        lastDate === null || Temporal.PlainDate.compare(endPlain, lastDate) > 0 ? endPlain : lastDate
+      ]
+    }, [null, null])
+
+    // If there are no scheduled programs, show only the current date
+    if (firstDate === null || lastDate === null) {
+      return [Temporal.Now.plainDateISO(LOCAL_TIMEZONE)]
+    }
+
+    // Start one day before the first date and end one day after the last date
+    firstDate = firstDate.subtract({ days: 1 })
+    lastDate = lastDate.add({ days: 1 })
+
+    // Get all dates between the first and last date
+    let last = firstDate
+    const dates = [last]
+    while (Temporal.PlainDateTime.compare(last, lastDate) < 0) {
+      last = last.add(Temporal.Duration.from({ days: 1 }))
+      dates.push(last)
+    }
+    return dates
+  }, [scheduledPlannables])
+
+  const atendeeGroups = useGroups()
+
+  // Show virtual group on the top, if there are no groups or if there are programs without groups
+  const hasAtLeastOneGroup = atendeeGroups.length > 0
+  const programsWithoutGroups = scheduledPlannables.filter(it => it.groups.length === 0)
+  const showVirtualGroup = !hasAtLeastOneGroup || programsWithoutGroups.length > 0
+  const shownGroups: string[] | [null, ...string[]] = useMemo(() => {
+    const sortedAttendeGroupIds = atendeeGroups.map(it => it._id)
+    return showVirtualGroup ? [null, ...sortedAttendeGroupIds] : sortedAttendeGroupIds
+  }, [atendeeGroups, showVirtualGroup])
+
+
+  // Owner filtering
+  const [ownerFilter, setOwnerFilter] = useState<string | null>(null)
+  const people = usePeople()
+  const availableOwners = useMemo(() => {
+    const result: { id: string, name: string, count: number }[] = []
+    for (const program of programs) {
+      for (const { person: ownerId } of program.people) {
+        let ownerRecord = result.find(it => it.id === ownerId);
+        if (!ownerRecord) {
+          const person = people.find(it => it._id === ownerId)
+          ownerRecord = { id: ownerId, name: person!.name, count: 0 }
+          result.push(ownerRecord)
+        }
+        ownerRecord!.count++
+      }
+    }
+    result.sort((a, b) => a.name.localeCompare(b.name))
+    return result
+  }, [programs, people])
+
+  const createSegmentsForPlannable = useCallback(function <T extends Program>(plannable: T, opts: T extends ScheduledProgram ? { start?: Temporal.PlainDateTime } : { start: Temporal.PlainDateTime }): Segment[] {
+    const start = opts?.start ?? Temporal.Instant.fromEpochMilliseconds(plannable.begin!).toZonedDateTimeISO(LOCAL_TIMEZONE).toPlainDateTime()
+    const duration = Temporal.Duration.from({ milliseconds: plannable.duration })
+    const end = start.add(duration)
+
+    const shownInGroups = plannable.groups.length === 0 ? [null] : plannable.groups
+    const segmentsFromAtendeeGroups = groupNeighbours(
+      shownInGroups.map(groupId => shownGroups.indexOf(groupId))
+    )
+
+    // Find all dates between start and end (inclusive)
+    let endDate = start.toPlainDate()
+    const dates = [endDate]
+    while (!endDate.equals(end.toPlainDate())) {
+      endDate = endDate.add({ days: 1 })
+      dates.push(endDate)
+    }
+
+    return segmentsFromAtendeeGroups.flatMap(atendeeGroups => dates.map((date, dateIndex) => {
+      return {
+        plannable,
+        date,
+        start: dateIndex === 0 ? start.toPlainTime() : null,
+        end: dateIndex === dates.length - 1 ? end.toPlainTime() : null,
+        atendeeGroups,
+      }
+    }))
+  }, [shownGroups])
+
+  const segments = useMemo(() => {
+    return scheduledPlannables.flatMap(it => createSegmentsForPlannable(it, {}))
+  }, [scheduledPlannables, createSegmentsForPlannable])
+
+
+  const [draggingPlannable, setDraggingPlannable] = useState<{ id: string, widthRatio?: number } | null>(null)
+  const [draggingPlannableStart, setDraggingPlannableStart] = useState<Temporal.PlainDateTime | null>(null)
+  const shadowSegments = useMemo(() => {
+    if (draggingPlannable === null || draggingPlannableStart === null) {
+      return []
+    }
+    const plannable = programs.find(it => it._id === draggingPlannable.id)!
+    return createSegmentsForPlannable(plannable, { start: draggingPlannableStart })
+  }, [draggingPlannable, draggingPlannableStart, programs, createSegmentsForPlannable])
+
+
+  const [earliestTime, latestTime] = useMemo(() => {
+    const minSegmentShownDuration = Temporal.Duration.from({ minutes: 60 });
+
+    const segmentStarts = segments.map(it => it.start).filter((it): it is Temporal.PlainTime => it !== null);
+    const segmentEnds = segments.map(it => it.end).filter((it): it is Temporal.PlainTime => it !== null);
+
+    const earliest = minTime(
+      Temporal.PlainTime.from('08:00'),
+      ...segmentStarts,
+      ...segmentEnds,
+      ...segmentEnds.map((it) => it.subtract(minSegmentShownDuration)),
+    )
+      .round({ roundingIncrement: 30, smallestUnit: 'minutes', roundingMode: 'trunc' })
+
+    const minLatest = Temporal.PlainTime.from('20:00');
+    const endOfDay = Temporal.PlainTime.from('23:59');
+    let latest = maxTime(
+      minLatest,
+      ...segmentStarts,
+      ...segmentEnds,
+      ...segmentStarts.map((it) => it.add(minSegmentShownDuration))
+    )
+      .round({ roundingIncrement: 30, smallestUnit: 'minutes', roundingMode: 'ceil' })
+
+    if (Temporal.PlainTime.compare(minLatest, latest) == 1 || Temporal.PlainTime.compare(latest, endOfDay.subtract(minSegmentShownDuration)) == 1) {
+      // Some segment has wrapped over
+      latest = endOfDay
+    }
+
+    return [earliest, latest]
+  }, [segments])
+
+  const dayLength = useMemo(() => {
+    return earliestTime.until(latestTime)
+  }, [earliestTime, latestTime])
+
+  const timeLabels = useMemo(() => {
+    const timeStep = widthScale > 2.5 ? 5 : widthScale >= 1.1 ? 15 : 30;
+    const dayMinutes = dayLength.total({ unit: 'minutes' })
+    const labels: Temporal.PlainTime[] = []
+    for (let i = 0; i <= dayMinutes; i += timeStep) {
+      labels.push(earliestTime.add({ minutes: i }))
+    }
+    return labels
+  }, [earliestTime, dayLength, widthScale])
+
+  const [hoveringPlannable, setHoveringPlannable] = useState<HoverStatusExtended>(null)
+  const ref = useRef<HTMLDivElement>(null)
+
+  const getDateTimeForPosition = useCallback(([clientX, clientY]: [number, number], minutesOffset: number = 0): Temporal.PlainDateTime | null => {
+    for (const dayEl of ref.current?.querySelectorAll('.scheduleTable__day') ?? []) {
+      const rect = dayEl.getBoundingClientRect()
+      if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
+        const day = Temporal.PlainDate.from(dayEl.getAttribute('data-date')!)
+        const alignTo = rect.width > 3000 ? 1 : 5
+        const relativeX = (clientX - rect.left) / rect.width
+
+        const time = earliestTime.add({ minutes: Math.floor(relativeX * dayLength.total({ unit: 'minutes' }) - minutesOffset) }).round({
+          roundingIncrement: alignTo,
+          smallestUnit: 'minutes',
+          roundingMode: 'floor'
+        })
+        return day.toPlainDateTime(time)
+      }
+    }
+    return null
+  }, [ref, dayLength, earliestTime])
+
+  const onDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (e.dataTransfer.types.includes(MIME_TYPE) && draggingPlannable !== null) {
+      e.preventDefault()
+      const widthRatio = draggingPlannable.widthRatio ?? 0
+      const plannable = programs.find(it => it._id === draggingPlannable.id)!
+      const duration = Temporal.Duration.from({ milliseconds: plannable.duration })
+      const offset = duration.total({ unit: 'minutes' }) * widthRatio
+      setDraggingPlannableStart(getDateTimeForPosition([e.clientX, e.clientY], offset))
+    }
+  }, [setDraggingPlannableStart, earliestTime, draggingPlannable, programs, getDateTimeForPosition])
+
+  const updateProgram = useUpdateProgram()
+  const onDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (e.dataTransfer.types.includes(MIME_TYPE)) {
+      e.preventDefault()
+      if (draggingPlannable === null || draggingPlannableStart === null) {
+        return
+      }
+
+      const plannable = programs.find(it => it._id === draggingPlannable.id)!
+      updateProgram({
+        ...plannable,
+        begin: draggingPlannableStart.toZonedDateTime(LOCAL_TIMEZONE).toInstant().epochMilliseconds,
+      })
+      setDraggingPlannable(null)
+      setDraggingPlannableStart(null)
+    }
+  }, [draggingPlannable, draggingPlannableStart, programs, setDraggingPlannable, setDraggingPlannableStart, updateProgram])
+
+
+  const onTrayDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (e.dataTransfer.types.includes(MIME_TYPE)) {
+      e.preventDefault()
+      setDraggingPlannableStart(null)
+    }
+  }, [ref, setDraggingPlannableStart])
+
+  const onTrayDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (e.dataTransfer.types.includes(MIME_TYPE)) {
+      e.preventDefault()
+      if (draggingPlannable === null || draggingPlannableStart !== null) {
+        return
+      }
+
+      const plannable = programs.find(it => it._id === draggingPlannable.id)!
+      updateProgram({
+        ...plannable,
+        begin: null,
+      })
+      setDraggingPlannable(null)
+      setDraggingPlannableStart(null)
+    }
+  }, [draggingPlannable, draggingPlannableStart, programs, setDraggingPlannable, setDraggingPlannableStart])
+
+  const navigate = useNavigate();
+
+  const onCreateTrayItem = useCallback(() => {
+    navigate('add');
+  }, [navigate]);
+
+  const onClickToCreate = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const start = getDateTimeForPosition([e.clientX, e.clientY])
+    if (!start) {
+      return
+    }
+    const begin = start.toZonedDateTime(LOCAL_TIMEZONE).toInstant().epochMilliseconds;
+    navigate('add', { state: { begin } });
+  }, [getDateTimeForPosition])
+
+  const addProgram = useAddProgram()
+  const onCopy = useCallback((id: string, times: number) => {
+    const trayItem = programs.find(it => it._id === id)
+    if (!trayItem || !trayItem.begin) {
+      return
+    }
+
+    for (let i = 0; i < times; i++) {
+      const originalStart = Temporal.Instant.fromEpochMilliseconds(trayItem.begin!).toZonedDateTimeISO(LOCAL_TIMEZONE).toPlainDateTime()
+      const newStart = originalStart.add({ days: i + 1 }).toZonedDateTime(LOCAL_TIMEZONE);
+      addProgram({
+        ...trayItem,
+        _id: undefined,
+        begin: newStart.toInstant().epochMilliseconds,
+      })
+    }
+  }, [addProgram, programs])
+
+
+  const setEditingTrayItem = useCallback((programId: string) => {
+    navigate(`edit/${programId}`);
+  }, [navigate])
+  const programmeGroups = usePkgs()
+
+  return (
+    <div className="schedulePage scheme-light">
+      <div className="schedulePage__mainContent">
+        <div className="schedulePage__tableSegment">
+          <div
+            ref={ref}
+            className="scheduleTable"
+            style={{
+              '--groups-count': shownGroups.length,
+              '--days-count': dates.length,
+              '--width-scale': widthScale,
+            } as any}
+            {...(editable ? {
+              onDragOver: onDragOver,
+              onDrop: onDrop,
+              onClick: onClickToCreate,
+            } : {})}
+          >
+            <DataLabels dates={dates} virtualGroupShown={showVirtualGroup} />
+
+            <TimeLabels
+              earliestTime={earliestTime}
+              timeLabels={timeLabels}
+              dayLength={dayLength}
+            />
+
+            {[...segments].map((segment, index) => {
+              return (
+                <SegmentBox
+                  key={segment.plannable._id}
+                  segment={segment}
+                  earliestTime={earliestTime}
+                  latestTime={latestTime}
+                  isHovering={hoveringPlannable?.id === segment.plannable._id ? hoveringPlannable : null}
+                  isDragged={draggingPlannable?.id === segment.plannable._id}
+                  setHovering={isHovering => setHoveringPlannable(isHovering ? {
+                    ...isHovering,
+                    id: segment.plannable._id
+                  } : null)}
+                  dayIndex={dates.findIndex(it => it.equals(segment.date))}
+                  onDragStart={(widthRatio) => {
+                    setDraggingPlannable({ id: segment.plannable._id, widthRatio })
+                  }}
+                  onDragEnd={() => {
+                    setDraggingPlannable(null)
+                    setDraggingPlannableStart(null)
+                  }}
+                  onClick={() => {
+                    setEditingTrayItem(segment.plannable._id)
+                  }}
+                  onContextMenu={!editable ? undefined : (x, y) => {
+                    setContextMenu({
+                      x,
+                      y,
+                      id: segment.plannable._id,
+                    })
+                  }}
+                  editable={editable && !segment.plannable.locked}
+                  isHighlighted={ownerFilter ? segment.plannable.people.find(it => it.person === ownerFilter) !== undefined : null}
+                  violations={violations.get(segment.plannable._id) ?? []}
+                />
+              );
+            })}
+
+            {...shadowSegments.map((segment, index) => (
+              <SegmentBox
+                key={index}
+                segment={segment}
+                earliestTime={earliestTime}
+                latestTime={latestTime}
+                isHovering={null}
+                setHovering={isHovering => { }}
+                dayIndex={dates.findIndex(it => it.equals(segment.date))}
+                onDragStart={(widthRatio) => {
+                  setDraggingPlannable({
+                    id: segment.plannable._id,
+                    widthRatio,
+                  })
+                }}
+                onDragEnd={() => {
+                  setDraggingPlannable(null)
+                  setDraggingPlannableStart(null)
+                }}
+                onClick={() => {
+                  setEditingTrayItem(segment.plannable._id)
+                }}
+                editable={editable}
+                isHighlighted={null}
+                violations={violations.get(segment.plannable._id) ?? []}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="schedulePage__bottomControls">
+          <div className="schedulePage__bottomControlsLeft">
+            <label>
+              Majitel programu:{' '}
+              <select value={ownerFilter ?? ''} onChange={(e) => setOwnerFilter(e.target.value)}>
+                <option value="">Všichni</option>
+                {availableOwners.map(it => (
+                  <option key={it.id} value={it.id}>{it.name} ({it.count})</option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="schedulePage__bottomControlsRight">
+            <label>
+              🔎
+              <input type="range" min={1} max={3} step={0.1} value={widthScale} onChange={(e) => setWidthScale(parseFloat(e.target.value))} />
+            </label>
+          </div>
+        </div>
+      </div>
+
+
+
+      {editable && (
+        <div
+          className="schedulePage__tray"
+          onDragOver={onTrayDragOver}
+          onDrop={onTrayDrop}
+        >
+          <div className="schedulePage_trayHeader">
+            <h2 className="schedulePage_trayHeaderTitle">Odkladiště</h2>
+            <Button onClick={onCreateTrayItem} variant="outline-primary" size="sm"><i className="fa fa-plus"></i></Button>
+          </div>
+          {notScheduledPlannables.map(plannable => {
+            const color = (plannable.pkg ? programmeGroups.find(it => it._id === plannable.pkg)?.color : null) ?? DEFAULT_PROGRAM_COLOR;
+            const isDark = color !== null ? isColorDark(color) : false;
+            return (
+              <div
+                key={plannable._id}
+                className={[
+                  'schedulePage__traySegment',
+                  isDark && 'schedulePage__traySegment--dark',
+                ].filter(Boolean).join(' ')}
+                style={{
+                  '--segment-color': color,
+                } as any}
+
+                draggable={true}
+                onDragStart={(e) => {
+                  e.dataTransfer.setData(MIME_TYPE, plannable._id as string)
+                  e.dataTransfer.effectAllowed = "move"
+                  setDraggingPlannable({ id: plannable._id })
+                }}
+                onClick={() => {
+                  setEditingTrayItem(plannable._id)
+                }}
+              >
+                {plannable.title}
+              </div>
+            );
+          }
+          )}
+        </div>
+      )}
+
+      {contextMenu && contextMenuProgram && (
+        <div className="contextMenu__wrapper" onClick={() => {
+          setContextMenu(null)
+        }}>
+          <div
+            className="contextMenu"
+            style={{
+              '--position-x': `${contextMenu.x}px`,
+              '--position-y': `${contextMenu.y}px`,
+            } as any}
+          >
+            {contextMenuProgram.locked ? (
+              <>
+                <div className="contextMenu__item" onClick={() => {
+                  setContextMenu(null)
+                  updateProgram({ ...contextMenuProgram, locked: false });
+                }
+                }>
+                  Odemknout
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="contextMenu__item" onClick={() => {
+                  setContextMenu(null)
+                  onCopy(contextMenu.id, 1)
+                }}>
+                  Opakovat další den
+                </div>
+                <div className="contextMenu__item" onClick={() => {
+                  setContextMenu(null)
+                  updateProgram({ ...contextMenuProgram, locked: true });
+                }}>
+                  Zamknout
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/TimetableV2.tsx
+++ b/src/components/TimetableV2.tsx
@@ -1,17 +1,21 @@
-import React, { Fragment, useCallback, useMemo, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
-import { useGetGroupsQuery } from '../store/groupsApi';
-import { useGetPackagesQuery } from '../store/packagesApi';
-import { useGetProgramsQuery, useUpdateProgramMutation, useAddProgramMutation } from '../store/programsApi';
-import { useGetPeopleQuery } from '../store/peopleApi';
+import React, { Fragment, useCallback, useMemo, useRef, useState } from "react";
+import { useSelector } from "react-redux";
+import { useGetGroupsQuery } from "../store/groupsApi";
+import { useGetPackagesQuery } from "../store/packagesApi";
+import {
+  useGetProgramsQuery,
+  useUpdateProgramMutation,
+  useAddProgramMutation,
+} from "../store/programsApi";
+import { useGetPeopleQuery } from "../store/peopleApi";
 import { Temporal } from "@js-temporal/polyfill";
 import { isColorDark } from "../helpers/isColorDark";
 import { maxTime, minTime } from "../helpers/timeCompare";
-import { level } from '../helpers/Level';
-import { useNavigate } from 'react-router-dom';
-import Button from 'react-bootstrap/Button';
+import { level } from "../helpers/Level";
+import { useNavigate } from "react-router-dom";
+import Button from "react-bootstrap/Button";
 
-const DEFAULT_PROGRAM_COLOR = '#81d4fa'
+const DEFAULT_PROGRAM_COLOR = "#81d4fa";
 
 interface Program {
   pkg: string | null;
@@ -28,8 +32,8 @@ interface Program {
   url: string;
   groups: string[];
 }
-type ScheduledProgram = Program & { begin: number }
-type UnscheduledProgram = Program & { begin: null }
+type ScheduledProgram = Program & { begin: number };
+type UnscheduledProgram = Program & { begin: null };
 
 interface Pkg {
   _id: string;
@@ -48,7 +52,7 @@ interface Person {
   name: string;
 }
 
-type Violation = { msg: string, program: string, satisied?: boolean };
+type Violation = { msg: string; program: string; satisied?: boolean };
 type Violations = Map<string, Violation[]>;
 
 export default function Timetable({
@@ -60,7 +64,12 @@ export default function Timetable({
   printView: boolean;
 }) {
   const { userLevel } = useSelector<any, any>((state) => state.auth);
-  return <ComposeSchedule editable={userLevel >= level.EDIT && !printView} violations={violations} />;
+  return (
+    <ComposeSchedule
+      editable={userLevel >= level.EDIT && !printView}
+      violations={violations}
+    />
+  );
 }
 
 function usePrograms(): Program[] {
@@ -95,7 +104,7 @@ function useUpdateProgram(): (program: Program) => void {
   };
 }
 
-type NewProgram = Omit<Program, '_id'> & { _id: any };
+type NewProgram = Omit<Program, "_id"> & { _id: any };
 function useAddProgram(): (program: NewProgram) => void {
   const { table } = useSelector<any, any>((state) => state.auth);
   const [addProgramMutation] = useAddProgramMutation();
@@ -105,31 +114,40 @@ function useAddProgram(): (program: NewProgram) => void {
   };
 }
 
+const LOCAL_TIMEZONE = Temporal.TimeZone.from("UTC");
 
-const LOCAL_TIMEZONE = Temporal.TimeZone.from('UTC');
+const MIME_TYPE = "application/prs.plannable";
 
-const MIME_TYPE = 'application/prs.plannable'
-
-type Segment = { date: Temporal.PlainDate; plannable: Program; start: Temporal.PlainTime | null; end: Temporal.PlainTime | null; atendeeGroups: number[] }
+type Segment = {
+  date: Temporal.PlainDate;
+  plannable: Program;
+  start: Temporal.PlainTime | null;
+  end: Temporal.PlainTime | null;
+  atendeeGroups: number[];
+};
 
 /**
  * Groups neighbouring numbers into arrays of consecutive numbers
  * @param _items Array of numbers
  * @returns Array of arrays of consecutive numbers
- * 
+ *
  * @example
  * groupNeighbours([1, 2, 3, 5, 6, 8, 9, 10])
  * // => [[1, 2, 3], [5, 6], [8, 9, 10]]
  */
 function groupNeighbours(_items: number[]): number[][] {
   const items = [..._items];
-  items.sort()
+  items.sort();
   const result: number[][] = [];
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
 
-    if (result.length === 0 || result[result.length - 1][result[result.length - 1].length - 1] !== item - 1) {
+    if (
+      result.length === 0 ||
+      result[result.length - 1][result[result.length - 1].length - 1] !==
+        item - 1
+    ) {
       result.push([item]);
     } else {
       result[result.length - 1].push(item);
@@ -140,15 +158,15 @@ function groupNeighbours(_items: number[]): number[][] {
 }
 
 type HoverStatus = null | {
-  clientX: number,
-  clientY: number,
-}
+  clientX: number;
+  clientY: number;
+};
 
 type HoverStatusExtended = null | {
-  clientX: number,
-  clientY: number,
-  id: string,
-}
+  clientX: number;
+  clientY: number;
+  id: string;
+};
 
 interface SegmentBoxProps {
   segment: Segment;
@@ -167,21 +185,45 @@ interface SegmentBoxProps {
   violations: Violation[];
 }
 
-function SegmentBox({ segment, earliestTime, latestTime, isHovering, isDragged = false, setHovering, dayIndex, onDragStart, onDragEnd, onClick, onContextMenu, editable, isHighlighted, violations }: SegmentBoxProps) {
-  const program = segment.plannable
-  const dayLength = earliestTime.until(latestTime)
-  const setStartTime = segment.start ?? earliestTime
-  const startTime = Temporal.PlainTime.compare(setStartTime, earliestTime) < 0 ? earliestTime : setStartTime
-  const startOffset = earliestTime.until(startTime).total({ unit: 'seconds' }) / dayLength.total({ unit: 'seconds' })
-  const setEndTime = segment.end ?? latestTime
-  const endTime = Temporal.PlainTime.compare(setEndTime, latestTime) > 0 ? latestTime : setEndTime
-  const duration = startTime.until(endTime)
-  const relativeDuration = duration.total({ unit: 'seconds' }) / dayLength.total({ unit: 'seconds' })
+function SegmentBox({
+  segment,
+  earliestTime,
+  latestTime,
+  isHovering,
+  isDragged = false,
+  setHovering,
+  dayIndex,
+  onDragStart,
+  onDragEnd,
+  onClick,
+  onContextMenu,
+  editable,
+  isHighlighted,
+  violations,
+}: SegmentBoxProps) {
+  const program = segment.plannable;
+  const dayLength = earliestTime.until(latestTime);
+  const setStartTime = segment.start ?? earliestTime;
+  const startTime =
+    Temporal.PlainTime.compare(setStartTime, earliestTime) < 0
+      ? earliestTime
+      : setStartTime;
+  const startOffset =
+    earliestTime.until(startTime).total({ unit: "seconds" }) /
+    dayLength.total({ unit: "seconds" });
+  const setEndTime = segment.end ?? latestTime;
+  const endTime =
+    Temporal.PlainTime.compare(setEndTime, latestTime) > 0
+      ? latestTime
+      : setEndTime;
+  const duration = startTime.until(endTime);
+  const relativeDuration =
+    duration.total({ unit: "seconds" }) / dayLength.total({ unit: "seconds" });
 
-  const [clickWidthRatio, setClickWidthRatio] = useState(0)
+  const [clickWidthRatio, setClickWidthRatio] = useState(0);
 
   if (dayIndex < 0) {
-    return null
+    return null;
   }
 
   const pkgs = usePkgs();
@@ -189,98 +231,129 @@ function SegmentBox({ segment, earliestTime, latestTime, isHovering, isDragged =
   const color = pkg?.color ?? DEFAULT_PROGRAM_COLOR;
   const isDark = color !== null && isColorDark(color);
   const people = usePeople();
-  const ownerNames = segment.plannable.people.map((person) => (people.find((p) => p._id === person.person))?.name ?? person.person).join(', ');
+  const ownerNames = segment.plannable.people
+    .map(
+      (person) =>
+        people.find((p) => p._id === person.person)?.name ?? person.person,
+    )
+    .join(", ");
   return (
     <div
       className={[
-        'scheduleTable__plannable',
-        isHovering != null && 'scheduleTable__plannable--hovering',
-        isDragged && 'scheduleTable__plannable--dragged',
-        (segment.start?.equals(startTime)) && 'scheduleTable__plannable--start',
-        (segment.end?.equals(endTime)) && 'scheduleTable__plannable--end',
-        isDark && 'scheduleTable__plannable--dark',
-        isHighlighted && 'scheduleTable__plannable--highlighted',
-        isHighlighted === false && 'scheduleTable__plannable--notHighlighted',
-        violations.length > 0 && 'scheduleTable__plannable--violated',
-      ].filter(Boolean).join(' ')}
-      style={{
-        '--segment-day': dayIndex,
-        '--segment-start': startOffset,
-        '--segment-duration': relativeDuration,
-        '--segment-group-first': segment.atendeeGroups[0],
-        '--segment-groups-count': segment.atendeeGroups.length,
-        '--segment-color': color,
-      } as any}
-
-      onMouseEnter={(e) => setHovering({ clientX: e.clientX, clientY: e.clientY })}
-      onMouseMove={(e) => setHovering({ clientX: e.clientX, clientY: e.clientY })}
+        "scheduleTable__plannable",
+        isHovering != null && "scheduleTable__plannable--hovering",
+        isDragged && "scheduleTable__plannable--dragged",
+        segment.start?.equals(startTime) && "scheduleTable__plannable--start",
+        segment.end?.equals(endTime) && "scheduleTable__plannable--end",
+        isDark && "scheduleTable__plannable--dark",
+        isHighlighted && "scheduleTable__plannable--highlighted",
+        isHighlighted === false && "scheduleTable__plannable--notHighlighted",
+        violations.length > 0 && "scheduleTable__plannable--violated",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={
+        {
+          "--segment-day": dayIndex,
+          "--segment-start": startOffset,
+          "--segment-duration": relativeDuration,
+          "--segment-group-first": segment.atendeeGroups[0],
+          "--segment-groups-count": segment.atendeeGroups.length,
+          "--segment-color": color,
+        } as any
+      }
+      onMouseEnter={(e) =>
+        setHovering({ clientX: e.clientX, clientY: e.clientY })
+      }
+      onMouseMove={(e) =>
+        setHovering({ clientX: e.clientX, clientY: e.clientY })
+      }
       onMouseLeave={() => setHovering(null)}
+      {...(editable
+        ? {
+            draggable: true,
+            onDragStart: (e) => {
+              e.dataTransfer.setData(MIME_TYPE, program._id as string);
+              e.dataTransfer.effectAllowed = "move";
 
-      {...(editable ? {
-        draggable: true,
-        onDragStart: (e) => {
-          e.dataTransfer.setData(MIME_TYPE, program._id as string)
-          e.dataTransfer.effectAllowed = "move"
+              const canvas = document.createElement("canvas");
+              canvas.width = canvas.height = 0;
+              e.dataTransfer.setDragImage(canvas, 25, 25);
 
-          const canvas = document.createElement("canvas");
-          canvas.width = canvas.height = 0;
-          e.dataTransfer.setDragImage(canvas, 25, 25);
-
-          onDragStart(clickWidthRatio)
-        },
-        onDragEnd: () => {
-          onDragEnd()
-        },
-        onMouseDown: (e) => {
-          if (segment.start !== null && segment.end !== null) {
-            setClickWidthRatio(e.nativeEvent.offsetX / e.currentTarget.offsetWidth)
-          } else {
-            setClickWidthRatio(0)
+              onDragStart(clickWidthRatio);
+            },
+            onDragEnd: () => {
+              onDragEnd();
+            },
+            onMouseDown: (e) => {
+              if (segment.start !== null && segment.end !== null) {
+                setClickWidthRatio(
+                  e.nativeEvent.offsetX / e.currentTarget.offsetWidth,
+                );
+              } else {
+                setClickWidthRatio(0);
+              }
+            },
           }
-        },
-      } : {})}
-
+        : {})}
       onClick={(e) => {
-        e.stopPropagation()
-        onClick()
+        e.stopPropagation();
+        onClick();
       }}
-      onContextMenu={onContextMenu ? e => {
-        e.preventDefault()
-        e.stopPropagation()
-        onContextMenu?.(e.clientX, e.clientY)
-      } : undefined}
+      onContextMenu={
+        onContextMenu
+          ? (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onContextMenu?.(e.clientX, e.clientY);
+            }
+          : undefined
+      }
     >
-      <div
-        className="scheduleTable__plannableTitle"
-      >
+      <div className="scheduleTable__plannableTitle">
         {program.locked && <i className="fa fa-lock me-1" />}
-        {violations.length > 0 && <i className="fa fa-exclamation-triangle me-1" />}
+        {violations.length > 0 && (
+          <i className="fa fa-exclamation-triangle me-1" />
+        )}
         {program.title}
       </div>
-      {ownerNames && <div className="scheduleTable__plannableOwners">{ownerNames}</div>}
-      {(isHovering != null && !isDragged) && (
+      {ownerNames && (
+        <div className="scheduleTable__plannableOwners">{ownerNames}</div>
+      )}
+      {isHovering != null && !isDragged && (
         <div
           className="scheduleTable__plannableExpansion"
-          style={{
-            '--position-x': `${isHovering.clientX}px`,
-            '--position-y': `${isHovering.clientY}px`,
-          } as any}
+          style={
+            {
+              "--position-x": `${isHovering.clientX}px`,
+              "--position-y": `${isHovering.clientY}px`,
+            } as any
+          }
         >
-          <div
-            className="scheduleTable__plannableTitle"
-          >
-            {program.title}
-          </div>
+          <div className="scheduleTable__plannableTitle">{program.title}</div>
           {violations.length > 0 && (
             <div className="scheduleTable__plannableOwners">
               <i className="fa fa-exclamation-triangle me-1" />
-              {violations.map((violation) => violation.msg).join(', ')}
+              {violations.map((violation) => violation.msg).join(", ")}
             </div>
           )}
-          <div className="scheduleTable__plannableOwners">{pkg?.name ?? "Bez balíčku"}</div>
-          {ownerNames && <div className="scheduleTable__plannableOwners">{ownerNames}</div>}
           <div className="scheduleTable__plannableOwners">
-            {startTime.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })} - {endTime.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })} ({duration.total({ unit: 'minute' })} min)
+            {pkg?.name ?? "Bez balíčku"}
+          </div>
+          {ownerNames && (
+            <div className="scheduleTable__plannableOwners">{ownerNames}</div>
+          )}
+          <div className="scheduleTable__plannableOwners">
+            {startTime.toLocaleString("cs-CZ", {
+              hour: "numeric",
+              minute: "2-digit",
+            })}{" "}
+            -{" "}
+            {endTime.toLocaleString("cs-CZ", {
+              hour: "numeric",
+              minute: "2-digit",
+            })}{" "}
+            ({duration.total({ unit: "minute" })} min)
           </div>
         </div>
       )}
@@ -299,32 +372,39 @@ function TimeLabels({ earliestTime, timeLabels, dayLength }: TimeLabelsProps) {
     <>
       <div className="scheduleTable__timeLabels">
         {timeLabels.map((label) => {
-          const startOffset = earliestTime.until(label).total({ unit: 'minutes' }) / dayLength.total({ unit: 'minutes' })
+          const startOffset =
+            earliestTime.until(label).total({ unit: "minutes" }) /
+            dayLength.total({ unit: "minutes" });
           return (
             <div
               key={label.toString()}
               className={`scheduleTable__timeLabel`}
-              style={{ '--time': startOffset } as any}
+              style={{ "--time": startOffset } as any}
             >
-              {label.toLocaleString('cs-CZ', { hour: 'numeric', minute: '2-digit' })}
+              {label.toLocaleString("cs-CZ", {
+                hour: "numeric",
+                minute: "2-digit",
+              })}
             </div>
-          )
+          );
         })}
       </div>
 
       {timeLabels.map((label) => {
-        const startOffset = earliestTime.until(label).total({ unit: 'minutes' }) / dayLength.total({ unit: 'minutes' })
-        const isMajor = label.minute === 0
+        const startOffset =
+          earliestTime.until(label).total({ unit: "minutes" }) /
+          dayLength.total({ unit: "minutes" });
+        const isMajor = label.minute === 0;
         return (
           <div
             key={label.toString()}
-            className={`scheduleTable__timeLine ${isMajor ? 'scheduleTable__timeLine--major' : ''}`}
-            style={{ '--time': startOffset } as any}
+            className={`scheduleTable__timeLine ${isMajor ? "scheduleTable__timeLine--major" : ""}`}
+            style={{ "--time": startOffset } as any}
           />
-        )
+        );
       })}
     </>
-  )
+  );
 }
 
 interface DataLabelsProps {
@@ -342,14 +422,18 @@ function DataLabels({ dates, virtualGroupShown }: DataLabelsProps) {
         <Fragment key={date.toString()}>
           <div
             className="scheduleTable__dayLabel"
-            style={{ '--day': index } as any}
+            style={{ "--day": index } as any}
           >
-            {date.toLocaleString('cs-CZ', { day: 'numeric', month: 'narrow', weekday: 'short' })}
+            {date.toLocaleString("cs-CZ", {
+              day: "numeric",
+              month: "narrow",
+              weekday: "short",
+            })}
           </div>
 
           <div
             className="scheduleTable__day"
-            style={{ '--day': index } as any}
+            style={{ "--day": index } as any}
             data-date={date.toString()}
           />
 
@@ -357,10 +441,12 @@ function DataLabels({ dates, virtualGroupShown }: DataLabelsProps) {
             <div
               key={group._id}
               className="scheduleTable__groupLabel"
-              style={{
-                '--group-day': index,
-                '--group-index': groupIndex + addGroupOffset,
-              } as any}
+              style={
+                {
+                  "--group-day": index,
+                  "--group-index": groupIndex + addGroupOffset,
+                } as any
+              }
             >
               {group.name}
             </div>
@@ -368,12 +454,12 @@ function DataLabels({ dates, virtualGroupShown }: DataLabelsProps) {
 
           <div
             className="scheduleTable__dayLine"
-            style={{ '--day': index } as any}
+            style={{ "--day": index } as any}
           />
         </Fragment>
       ))}
     </>
-  )
+  );
 }
 
 interface ComposeScheduleProps {
@@ -381,298 +467,449 @@ interface ComposeScheduleProps {
   violations: Violations;
 }
 
-export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) => {
-  const [widthScale, setWidthScale] = useState(1)
+export const ComposeSchedule = ({
+  editable,
+  violations,
+}: ComposeScheduleProps) => {
+  const [widthScale, setWidthScale] = useState(1);
 
   // Programs
-  const programs = usePrograms()
+  const programs = usePrograms();
   const scheduledPlannables = useMemo(() => {
-    return programs.filter((it): it is ScheduledProgram => it.begin !== null)
-  }, [programs])
+    return programs.filter((it): it is ScheduledProgram => it.begin !== null);
+  }, [programs]);
   const notScheduledPlannables = useMemo(() => {
-    return programs.filter((it): it is UnscheduledProgram => it.begin === null)
-  }, [programs])
+    return programs.filter((it): it is UnscheduledProgram => it.begin === null);
+  }, [programs]);
 
   // Context menu
-  const [contextMenu, setContextMenu] = useState<null | { x: number, y: number, id: string }>(null)
+  const [contextMenu, setContextMenu] = useState<null | {
+    x: number;
+    y: number;
+    id: string;
+  }>(null);
   const contextMenuProgram = useMemo(() => {
-    return programs.find(it => it._id === contextMenu?.id)
-  }, [programs, contextMenu])
+    return programs.find((it) => it._id === contextMenu?.id);
+  }, [programs, contextMenu]);
 
   // All dates of the schedule
   const dates = useMemo(() => {
-    const scheduledDateTimes = scheduledPlannables
-      .map((program): [Temporal.PlainDateTime, Temporal.Duration] => [
-        Temporal.Instant.fromEpochMilliseconds(program.begin).toZonedDateTimeISO(LOCAL_TIMEZONE).toPlainDateTime(),
+    const scheduledDateTimes = scheduledPlannables.map(
+      (program): [Temporal.PlainDateTime, Temporal.Duration] => [
+        Temporal.Instant.fromEpochMilliseconds(program.begin)
+          .toZonedDateTimeISO(LOCAL_TIMEZONE)
+          .toPlainDateTime(),
         Temporal.Duration.from({ milliseconds: program.duration }),
-      ])
+      ],
+    );
 
     // Find the first and last date of the schedule
-    let [firstDate, lastDate] = scheduledDateTimes.reduce<[Temporal.PlainDate | null, Temporal.PlainDate | null]>(([firstDate, lastDate], [start, duration]) => {
-      const startPlain = start.toPlainDate()
-      const endPlain = start.add(duration).toPlainDate()
-      return [
-        firstDate === null || Temporal.PlainDate.compare(startPlain, firstDate) < 0 ? startPlain : firstDate,
-        lastDate === null || Temporal.PlainDate.compare(endPlain, lastDate) > 0 ? endPlain : lastDate
-      ]
-    }, [null, null])
+    let [firstDate, lastDate] = scheduledDateTimes.reduce<
+      [Temporal.PlainDate | null, Temporal.PlainDate | null]
+    >(
+      ([firstDate, lastDate], [start, duration]) => {
+        const startPlain = start.toPlainDate();
+        const endPlain = start.add(duration).toPlainDate();
+        return [
+          firstDate === null ||
+          Temporal.PlainDate.compare(startPlain, firstDate) < 0
+            ? startPlain
+            : firstDate,
+          lastDate === null ||
+          Temporal.PlainDate.compare(endPlain, lastDate) > 0
+            ? endPlain
+            : lastDate,
+        ];
+      },
+      [null, null],
+    );
 
     // If there are no scheduled programs, show only the current date
     if (firstDate === null || lastDate === null) {
-      return [Temporal.Now.plainDateISO(LOCAL_TIMEZONE)]
+      return [Temporal.Now.plainDateISO(LOCAL_TIMEZONE)];
     }
 
     // Start one day before the first date and end one day after the last date
-    firstDate = firstDate.subtract({ days: 1 })
-    lastDate = lastDate.add({ days: 1 })
+    firstDate = firstDate.subtract({ days: 1 });
+    lastDate = lastDate.add({ days: 1 });
 
     // Get all dates between the first and last date
-    let last = firstDate
-    const dates = [last]
+    let last = firstDate;
+    const dates = [last];
     while (Temporal.PlainDateTime.compare(last, lastDate) < 0) {
-      last = last.add(Temporal.Duration.from({ days: 1 }))
-      dates.push(last)
+      last = last.add(Temporal.Duration.from({ days: 1 }));
+      dates.push(last);
     }
-    return dates
-  }, [scheduledPlannables])
+    return dates;
+  }, [scheduledPlannables]);
 
-  const atendeeGroups = useGroups()
+  const atendeeGroups = useGroups();
 
   // Show virtual group on the top, if there are no groups or if there are programs without groups
-  const hasAtLeastOneGroup = atendeeGroups.length > 0
-  const programsWithoutGroups = scheduledPlannables.filter(it => it.groups.length === 0)
-  const showVirtualGroup = !hasAtLeastOneGroup || programsWithoutGroups.length > 0
+  const hasAtLeastOneGroup = atendeeGroups.length > 0;
+  const programsWithoutGroups = scheduledPlannables.filter(
+    (it) => it.groups.length === 0,
+  );
+  const showVirtualGroup =
+    !hasAtLeastOneGroup || programsWithoutGroups.length > 0;
   const shownGroups: string[] | [null, ...string[]] = useMemo(() => {
-    const sortedAttendeGroupIds = atendeeGroups.map(it => it._id)
-    return showVirtualGroup ? [null, ...sortedAttendeGroupIds] : sortedAttendeGroupIds
-  }, [atendeeGroups, showVirtualGroup])
-
+    const sortedAttendeGroupIds = atendeeGroups.map((it) => it._id);
+    return showVirtualGroup
+      ? [null, ...sortedAttendeGroupIds]
+      : sortedAttendeGroupIds;
+  }, [atendeeGroups, showVirtualGroup]);
 
   // Owner filtering
-  const [ownerFilter, setOwnerFilter] = useState<string | null>(null)
-  const people = usePeople()
+  const [ownerFilter, setOwnerFilter] = useState<string | null>(null);
+  const people = usePeople();
   const availableOwners = useMemo(() => {
-    const result: { id: string, name: string, count: number }[] = []
+    const result: { id: string; name: string; count: number }[] = [];
     for (const program of programs) {
       for (const { person: ownerId } of program.people) {
-        let ownerRecord = result.find(it => it.id === ownerId);
+        let ownerRecord = result.find((it) => it.id === ownerId);
         if (!ownerRecord) {
-          const person = people.find(it => it._id === ownerId)
-          ownerRecord = { id: ownerId, name: person!.name, count: 0 }
-          result.push(ownerRecord)
+          const person = people.find((it) => it._id === ownerId);
+          ownerRecord = { id: ownerId, name: person!.name, count: 0 };
+          result.push(ownerRecord);
         }
-        ownerRecord!.count++
+        ownerRecord!.count++;
       }
     }
-    result.sort((a, b) => a.name.localeCompare(b.name))
-    return result
-  }, [programs, people])
+    result.sort((a, b) => a.name.localeCompare(b.name));
+    return result;
+  }, [programs, people]);
 
-  const createSegmentsForPlannable = useCallback(function <T extends Program>(plannable: T, opts: T extends ScheduledProgram ? { start?: Temporal.PlainDateTime } : { start: Temporal.PlainDateTime }): Segment[] {
-    const start = opts?.start ?? Temporal.Instant.fromEpochMilliseconds(plannable.begin!).toZonedDateTimeISO(LOCAL_TIMEZONE).toPlainDateTime()
-    const duration = Temporal.Duration.from({ milliseconds: plannable.duration })
-    const end = start.add(duration)
+  const createSegmentsForPlannable = useCallback(
+    function <T extends Program>(
+      plannable: T,
+      opts: T extends ScheduledProgram
+        ? { start?: Temporal.PlainDateTime }
+        : { start: Temporal.PlainDateTime },
+    ): Segment[] {
+      const start =
+        opts?.start ??
+        Temporal.Instant.fromEpochMilliseconds(plannable.begin!)
+          .toZonedDateTimeISO(LOCAL_TIMEZONE)
+          .toPlainDateTime();
+      const duration = Temporal.Duration.from({
+        milliseconds: plannable.duration,
+      });
+      const end = start.add(duration);
 
-    const shownInGroups = plannable.groups.length === 0 ? [null] : plannable.groups
-    const segmentsFromAtendeeGroups = groupNeighbours(
-      shownInGroups.map(groupId => shownGroups.indexOf(groupId))
-    )
+      const shownInGroups =
+        plannable.groups.length === 0 ? [null] : plannable.groups;
+      const segmentsFromAtendeeGroups = groupNeighbours(
+        shownInGroups.map((groupId) => shownGroups.indexOf(groupId)),
+      );
 
-    // Find all dates between start and end (inclusive)
-    let endDate = start.toPlainDate()
-    const dates = [endDate]
-    while (!endDate.equals(end.toPlainDate())) {
-      endDate = endDate.add({ days: 1 })
-      dates.push(endDate)
-    }
-
-    return segmentsFromAtendeeGroups.flatMap(atendeeGroups => dates.map((date, dateIndex) => {
-      return {
-        plannable,
-        date,
-        start: dateIndex === 0 ? start.toPlainTime() : null,
-        end: dateIndex === dates.length - 1 ? end.toPlainTime() : null,
-        atendeeGroups,
+      // Find all dates between start and end (inclusive)
+      let endDate = start.toPlainDate();
+      const dates = [endDate];
+      while (!endDate.equals(end.toPlainDate())) {
+        endDate = endDate.add({ days: 1 });
+        dates.push(endDate);
       }
-    }))
-  }, [shownGroups])
+
+      return segmentsFromAtendeeGroups.flatMap((atendeeGroups) =>
+        dates.map((date, dateIndex) => {
+          return {
+            plannable,
+            date,
+            start: dateIndex === 0 ? start.toPlainTime() : null,
+            end: dateIndex === dates.length - 1 ? end.toPlainTime() : null,
+            atendeeGroups,
+          };
+        }),
+      );
+    },
+    [shownGroups],
+  );
 
   const segments = useMemo(() => {
-    return scheduledPlannables.flatMap(it => createSegmentsForPlannable(it, {}))
-  }, [scheduledPlannables, createSegmentsForPlannable])
+    return scheduledPlannables.flatMap((it) =>
+      createSegmentsForPlannable(it, {}),
+    );
+  }, [scheduledPlannables, createSegmentsForPlannable]);
 
-
-  const [draggingPlannable, setDraggingPlannable] = useState<{ id: string, widthRatio?: number } | null>(null)
-  const [draggingPlannableStart, setDraggingPlannableStart] = useState<Temporal.PlainDateTime | null>(null)
+  const [draggingPlannable, setDraggingPlannable] = useState<{
+    id: string;
+    widthRatio?: number;
+  } | null>(null);
+  const [draggingPlannableStart, setDraggingPlannableStart] =
+    useState<Temporal.PlainDateTime | null>(null);
   const shadowSegments = useMemo(() => {
     if (draggingPlannable === null || draggingPlannableStart === null) {
-      return []
+      return [];
     }
-    const plannable = programs.find(it => it._id === draggingPlannable.id)!
-    return createSegmentsForPlannable(plannable, { start: draggingPlannableStart })
-  }, [draggingPlannable, draggingPlannableStart, programs, createSegmentsForPlannable])
-
+    const plannable = programs.find((it) => it._id === draggingPlannable.id)!;
+    return createSegmentsForPlannable(plannable, {
+      start: draggingPlannableStart,
+    });
+  }, [
+    draggingPlannable,
+    draggingPlannableStart,
+    programs,
+    createSegmentsForPlannable,
+  ]);
 
   const [earliestTime, latestTime] = useMemo(() => {
     const minSegmentShownDuration = Temporal.Duration.from({ minutes: 60 });
 
-    const segmentStarts = segments.map(it => it.start).filter((it): it is Temporal.PlainTime => it !== null);
-    const segmentEnds = segments.map(it => it.end).filter((it): it is Temporal.PlainTime => it !== null);
+    const segmentStarts = segments
+      .map((it) => it.start)
+      .filter((it): it is Temporal.PlainTime => it !== null);
+    const segmentEnds = segments
+      .map((it) => it.end)
+      .filter((it): it is Temporal.PlainTime => it !== null);
 
     const earliest = minTime(
-      Temporal.PlainTime.from('08:00'),
+      Temporal.PlainTime.from("08:00"),
       ...segmentStarts,
       ...segmentEnds,
       ...segmentEnds.map((it) => it.subtract(minSegmentShownDuration)),
-    )
-      .round({ roundingIncrement: 30, smallestUnit: 'minutes', roundingMode: 'trunc' })
+    ).round({
+      roundingIncrement: 30,
+      smallestUnit: "minutes",
+      roundingMode: "trunc",
+    });
 
-    const minLatest = Temporal.PlainTime.from('20:00');
-    const endOfDay = Temporal.PlainTime.from('23:59');
+    const minLatest = Temporal.PlainTime.from("20:00");
+    const endOfDay = Temporal.PlainTime.from("23:59");
     let latest = maxTime(
       minLatest,
       ...segmentStarts,
       ...segmentEnds,
-      ...segmentStarts.map((it) => it.add(minSegmentShownDuration))
-    )
-      .round({ roundingIncrement: 30, smallestUnit: 'minutes', roundingMode: 'ceil' })
+      ...segmentStarts.map((it) => it.add(minSegmentShownDuration)),
+    ).round({
+      roundingIncrement: 30,
+      smallestUnit: "minutes",
+      roundingMode: "ceil",
+    });
 
-    if (Temporal.PlainTime.compare(minLatest, latest) == 1 || Temporal.PlainTime.compare(latest, endOfDay.subtract(minSegmentShownDuration)) == 1) {
+    if (
+      Temporal.PlainTime.compare(minLatest, latest) == 1 ||
+      Temporal.PlainTime.compare(
+        latest,
+        endOfDay.subtract(minSegmentShownDuration),
+      ) == 1
+    ) {
       // Some segment has wrapped over
-      latest = endOfDay
+      latest = endOfDay;
     }
 
-    return [earliest, latest]
-  }, [segments])
+    return [earliest, latest];
+  }, [segments]);
 
   const dayLength = useMemo(() => {
-    return earliestTime.until(latestTime)
-  }, [earliestTime, latestTime])
+    return earliestTime.until(latestTime);
+  }, [earliestTime, latestTime]);
 
   const timeLabels = useMemo(() => {
     const timeStep = widthScale > 2.5 ? 5 : widthScale >= 1.1 ? 15 : 30;
-    const dayMinutes = dayLength.total({ unit: 'minutes' })
-    const labels: Temporal.PlainTime[] = []
+    const dayMinutes = dayLength.total({ unit: "minutes" });
+    const labels: Temporal.PlainTime[] = [];
     for (let i = 0; i <= dayMinutes; i += timeStep) {
-      labels.push(earliestTime.add({ minutes: i }))
+      labels.push(earliestTime.add({ minutes: i }));
     }
-    return labels
-  }, [earliestTime, dayLength, widthScale])
+    return labels;
+  }, [earliestTime, dayLength, widthScale]);
 
-  const [hoveringPlannable, setHoveringPlannable] = useState<HoverStatusExtended>(null)
-  const ref = useRef<HTMLDivElement>(null)
+  const [hoveringPlannable, setHoveringPlannable] =
+    useState<HoverStatusExtended>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
-  const getDateTimeForPosition = useCallback(([clientX, clientY]: [number, number], minutesOffset: number = 0): Temporal.PlainDateTime | null => {
-    for (const dayEl of ref.current?.querySelectorAll('.scheduleTable__day') ?? []) {
-      const rect = dayEl.getBoundingClientRect()
-      if (clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom) {
-        const day = Temporal.PlainDate.from(dayEl.getAttribute('data-date')!)
-        const alignTo = rect.width > 3000 ? 1 : 5
-        const relativeX = (clientX - rect.left) / rect.width
+  const getDateTimeForPosition = useCallback(
+    (
+      [clientX, clientY]: [number, number],
+      minutesOffset: number = 0,
+    ): Temporal.PlainDateTime | null => {
+      for (const dayEl of ref.current?.querySelectorAll(
+        ".scheduleTable__day",
+      ) ?? []) {
+        const rect = dayEl.getBoundingClientRect();
+        if (
+          clientX >= rect.left &&
+          clientX <= rect.right &&
+          clientY >= rect.top &&
+          clientY <= rect.bottom
+        ) {
+          const day = Temporal.PlainDate.from(dayEl.getAttribute("data-date")!);
+          const alignTo = rect.width > 3000 ? 1 : 5;
+          const relativeX = (clientX - rect.left) / rect.width;
 
-        const time = earliestTime.add({ minutes: Math.floor(relativeX * dayLength.total({ unit: 'minutes' }) - minutesOffset) }).round({
-          roundingIncrement: alignTo,
-          smallestUnit: 'minutes',
-          roundingMode: 'floor'
-        })
-        return day.toPlainDateTime(time)
+          const time = earliestTime
+            .add({
+              minutes: Math.floor(
+                relativeX * dayLength.total({ unit: "minutes" }) -
+                  minutesOffset,
+              ),
+            })
+            .round({
+              roundingIncrement: alignTo,
+              smallestUnit: "minutes",
+              roundingMode: "floor",
+            });
+          return day.toPlainDateTime(time);
+        }
       }
-    }
-    return null
-  }, [ref, dayLength, earliestTime])
+      return null;
+    },
+    [ref, dayLength, earliestTime],
+  );
 
-  const onDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    if (e.dataTransfer.types.includes(MIME_TYPE) && draggingPlannable !== null) {
-      e.preventDefault()
-      const widthRatio = draggingPlannable.widthRatio ?? 0
-      const plannable = programs.find(it => it._id === draggingPlannable.id)!
-      const duration = Temporal.Duration.from({ milliseconds: plannable.duration })
-      const offset = duration.total({ unit: 'minutes' }) * widthRatio
-      setDraggingPlannableStart(getDateTimeForPosition([e.clientX, e.clientY], offset))
-    }
-  }, [setDraggingPlannableStart, earliestTime, draggingPlannable, programs, getDateTimeForPosition])
-
-  const updateProgram = useUpdateProgram()
-  const onDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    if (e.dataTransfer.types.includes(MIME_TYPE)) {
-      e.preventDefault()
-      if (draggingPlannable === null || draggingPlannableStart === null) {
-        return
+  const onDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (
+        e.dataTransfer.types.includes(MIME_TYPE) &&
+        draggingPlannable !== null
+      ) {
+        e.preventDefault();
+        const widthRatio = draggingPlannable.widthRatio ?? 0;
+        const plannable = programs.find(
+          (it) => it._id === draggingPlannable.id,
+        )!;
+        const duration = Temporal.Duration.from({
+          milliseconds: plannable.duration,
+        });
+        const offset = duration.total({ unit: "minutes" }) * widthRatio;
+        setDraggingPlannableStart(
+          getDateTimeForPosition([e.clientX, e.clientY], offset),
+        );
       }
+    },
+    [
+      setDraggingPlannableStart,
+      earliestTime,
+      draggingPlannable,
+      programs,
+      getDateTimeForPosition,
+    ],
+  );
 
-      const plannable = programs.find(it => it._id === draggingPlannable.id)!
-      updateProgram({
-        ...plannable,
-        begin: draggingPlannableStart.toZonedDateTime(LOCAL_TIMEZONE).toInstant().epochMilliseconds,
-      })
-      setDraggingPlannable(null)
-      setDraggingPlannableStart(null)
-    }
-  }, [draggingPlannable, draggingPlannableStart, programs, setDraggingPlannable, setDraggingPlannableStart, updateProgram])
+  const updateProgram = useUpdateProgram();
+  const onDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (e.dataTransfer.types.includes(MIME_TYPE)) {
+        e.preventDefault();
+        if (draggingPlannable === null || draggingPlannableStart === null) {
+          return;
+        }
 
-
-  const onTrayDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    if (e.dataTransfer.types.includes(MIME_TYPE)) {
-      e.preventDefault()
-      setDraggingPlannableStart(null)
-    }
-  }, [ref, setDraggingPlannableStart])
-
-  const onTrayDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    if (e.dataTransfer.types.includes(MIME_TYPE)) {
-      e.preventDefault()
-      if (draggingPlannable === null || draggingPlannableStart !== null) {
-        return
+        const plannable = programs.find(
+          (it) => it._id === draggingPlannable.id,
+        )!;
+        updateProgram({
+          ...plannable,
+          begin: draggingPlannableStart
+            .toZonedDateTime(LOCAL_TIMEZONE)
+            .toInstant().epochMilliseconds,
+        });
+        setDraggingPlannable(null);
+        setDraggingPlannableStart(null);
       }
+    },
+    [
+      draggingPlannable,
+      draggingPlannableStart,
+      programs,
+      setDraggingPlannable,
+      setDraggingPlannableStart,
+      updateProgram,
+    ],
+  );
 
-      const plannable = programs.find(it => it._id === draggingPlannable.id)!
-      updateProgram({
-        ...plannable,
-        begin: null,
-      })
-      setDraggingPlannable(null)
-      setDraggingPlannableStart(null)
-    }
-  }, [draggingPlannable, draggingPlannableStart, programs, setDraggingPlannable, setDraggingPlannableStart])
+  const onTrayDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (e.dataTransfer.types.includes(MIME_TYPE)) {
+        e.preventDefault();
+        setDraggingPlannableStart(null);
+      }
+    },
+    [ref, setDraggingPlannableStart],
+  );
+
+  const onTrayDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (e.dataTransfer.types.includes(MIME_TYPE)) {
+        e.preventDefault();
+        if (draggingPlannable === null || draggingPlannableStart !== null) {
+          return;
+        }
+
+        const plannable = programs.find(
+          (it) => it._id === draggingPlannable.id,
+        )!;
+        updateProgram({
+          ...plannable,
+          begin: null,
+        });
+        setDraggingPlannable(null);
+        setDraggingPlannableStart(null);
+      }
+    },
+    [
+      draggingPlannable,
+      draggingPlannableStart,
+      programs,
+      setDraggingPlannable,
+      setDraggingPlannableStart,
+    ],
+  );
 
   const navigate = useNavigate();
 
   const onCreateTrayItem = useCallback(() => {
-    navigate('add');
+    navigate("add");
   }, [navigate]);
 
-  const onClickToCreate = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const start = getDateTimeForPosition([e.clientX, e.clientY])
-    if (!start) {
-      return
-    }
-    const begin = start.toZonedDateTime(LOCAL_TIMEZONE).toInstant().epochMilliseconds;
-    navigate('add', { state: { begin } });
-  }, [getDateTimeForPosition])
+  const onClickToCreate = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const start = getDateTimeForPosition([e.clientX, e.clientY]);
+      if (!start) {
+        return;
+      }
+      const begin = start
+        .toZonedDateTime(LOCAL_TIMEZONE)
+        .toInstant().epochMilliseconds;
+      navigate("add", { state: { begin } });
+    },
+    [getDateTimeForPosition],
+  );
 
-  const addProgram = useAddProgram()
-  const onCopy = useCallback((id: string, times: number) => {
-    const trayItem = programs.find(it => it._id === id)
-    if (!trayItem || !trayItem.begin) {
-      return
-    }
+  const addProgram = useAddProgram();
+  const onCopy = useCallback(
+    (id: string, times: number) => {
+      const trayItem = programs.find((it) => it._id === id);
+      if (!trayItem || !trayItem.begin) {
+        return;
+      }
 
-    for (let i = 0; i < times; i++) {
-      const originalStart = Temporal.Instant.fromEpochMilliseconds(trayItem.begin!).toZonedDateTimeISO(LOCAL_TIMEZONE).toPlainDateTime()
-      const newStart = originalStart.add({ days: i + 1 }).toZonedDateTime(LOCAL_TIMEZONE);
-      addProgram({
-        ...trayItem,
-        _id: undefined,
-        begin: newStart.toInstant().epochMilliseconds,
-      })
-    }
-  }, [addProgram, programs])
+      for (let i = 0; i < times; i++) {
+        const originalStart = Temporal.Instant.fromEpochMilliseconds(
+          trayItem.begin!,
+        )
+          .toZonedDateTimeISO(LOCAL_TIMEZONE)
+          .toPlainDateTime();
+        const newStart = originalStart
+          .add({ days: i + 1 })
+          .toZonedDateTime(LOCAL_TIMEZONE);
+        addProgram({
+          ...trayItem,
+          _id: undefined,
+          begin: newStart.toInstant().epochMilliseconds,
+        });
+      }
+    },
+    [addProgram, programs],
+  );
 
-
-  const setEditingTrayItem = useCallback((programId: string) => {
-    navigate(`edit/${programId}`);
-  }, [navigate])
-  const programmeGroups = usePkgs()
+  const setEditingTrayItem = useCallback(
+    (programId: string) => {
+      navigate(`edit/${programId}`);
+    },
+    [navigate],
+  );
+  const programmeGroups = usePkgs();
 
   return (
     <div className="schedulePage scheme-light">
@@ -681,16 +918,20 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
           <div
             ref={ref}
             className="scheduleTable"
-            style={{
-              '--groups-count': shownGroups.length,
-              '--days-count': dates.length,
-              '--width-scale': widthScale,
-            } as any}
-            {...(editable ? {
-              onDragOver: onDragOver,
-              onDrop: onDrop,
-              onClick: onClickToCreate,
-            } : {})}
+            style={
+              {
+                "--groups-count": shownGroups.length,
+                "--days-count": dates.length,
+                "--width-scale": widthScale,
+              } as any
+            }
+            {...(editable
+              ? {
+                  onDragOver: onDragOver,
+                  onDrop: onDrop,
+                  onClick: onClickToCreate,
+                }
+              : {})}
           >
             <DataLabels dates={dates} virtualGroupShown={showVirtualGroup} />
 
@@ -707,32 +948,55 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
                   segment={segment}
                   earliestTime={earliestTime}
                   latestTime={latestTime}
-                  isHovering={hoveringPlannable?.id === segment.plannable._id ? hoveringPlannable : null}
+                  isHovering={
+                    hoveringPlannable?.id === segment.plannable._id
+                      ? hoveringPlannable
+                      : null
+                  }
                   isDragged={draggingPlannable?.id === segment.plannable._id}
-                  setHovering={isHovering => setHoveringPlannable(isHovering ? {
-                    ...isHovering,
-                    id: segment.plannable._id
-                  } : null)}
-                  dayIndex={dates.findIndex(it => it.equals(segment.date))}
+                  setHovering={(isHovering) =>
+                    setHoveringPlannable(
+                      isHovering
+                        ? {
+                            ...isHovering,
+                            id: segment.plannable._id,
+                          }
+                        : null,
+                    )
+                  }
+                  dayIndex={dates.findIndex((it) => it.equals(segment.date))}
                   onDragStart={(widthRatio) => {
-                    setDraggingPlannable({ id: segment.plannable._id, widthRatio })
+                    setDraggingPlannable({
+                      id: segment.plannable._id,
+                      widthRatio,
+                    });
                   }}
                   onDragEnd={() => {
-                    setDraggingPlannable(null)
-                    setDraggingPlannableStart(null)
+                    setDraggingPlannable(null);
+                    setDraggingPlannableStart(null);
                   }}
                   onClick={() => {
-                    setEditingTrayItem(segment.plannable._id)
+                    setEditingTrayItem(segment.plannable._id);
                   }}
-                  onContextMenu={!editable ? undefined : (x, y) => {
-                    setContextMenu({
-                      x,
-                      y,
-                      id: segment.plannable._id,
-                    })
-                  }}
+                  onContextMenu={
+                    !editable
+                      ? undefined
+                      : (x, y) => {
+                          setContextMenu({
+                            x,
+                            y,
+                            id: segment.plannable._id,
+                          });
+                        }
+                  }
                   editable={editable && !segment.plannable.locked}
-                  isHighlighted={ownerFilter ? segment.plannable.people.find(it => it.person === ownerFilter) !== undefined : null}
+                  isHighlighted={
+                    ownerFilter
+                      ? segment.plannable.people.find(
+                          (it) => it.person === ownerFilter,
+                        ) !== undefined
+                      : null
+                  }
                   violations={violations.get(segment.plannable._id) ?? []}
                 />
               );
@@ -746,19 +1010,19 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
                 latestTime={latestTime}
                 isHovering={null}
                 setHovering={() => {}}
-                dayIndex={dates.findIndex(it => it.equals(segment.date))}
+                dayIndex={dates.findIndex((it) => it.equals(segment.date))}
                 onDragStart={(widthRatio) => {
                   setDraggingPlannable({
                     id: segment.plannable._id,
                     widthRatio,
-                  })
+                  });
                 }}
                 onDragEnd={() => {
-                  setDraggingPlannable(null)
-                  setDraggingPlannableStart(null)
+                  setDraggingPlannable(null);
+                  setDraggingPlannableStart(null);
                 }}
                 onClick={() => {
-                  setEditingTrayItem(segment.plannable._id)
+                  setEditingTrayItem(segment.plannable._id);
                 }}
                 editable={editable}
                 isHighlighted={null}
@@ -770,11 +1034,16 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
         <div className="schedulePage__bottomControls">
           <div className="schedulePage__bottomControlsLeft">
             <label>
-              Majitel programu:{' '}
-              <select value={ownerFilter ?? ''} onChange={(e) => setOwnerFilter(e.target.value)}>
+              Majitel programu:{" "}
+              <select
+                value={ownerFilter ?? ""}
+                onChange={(e) => setOwnerFilter(e.target.value)}
+              >
                 <option value="">Všichni</option>
-                {availableOwners.map(it => (
-                  <option key={it.id} value={it.id}>{it.name} ({it.count})</option>
+                {availableOwners.map((it) => (
+                  <option key={it.id} value={it.id}>
+                    {it.name} ({it.count})
+                  </option>
                 ))}
               </select>
             </label>
@@ -783,13 +1052,18 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
           <div className="schedulePage__bottomControlsRight">
             <label>
               🔎
-              <input type="range" min={1} max={3} step={0.1} value={widthScale} onChange={(e) => setWidthScale(parseFloat(e.target.value))} />
+              <input
+                type="range"
+                min={1}
+                max={3}
+                step={0.1}
+                value={widthScale}
+                onChange={(e) => setWidthScale(parseFloat(e.target.value))}
+              />
             </label>
           </div>
         </div>
       </div>
-
-
 
       {editable && (
         <div
@@ -799,73 +1073,97 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
         >
           <div className="schedulePage_trayHeader">
             <h2 className="schedulePage_trayHeaderTitle">Odkladiště</h2>
-            <Button onClick={onCreateTrayItem} variant="outline-primary" size="sm"><i className="fa fa-plus"></i></Button>
+            <Button
+              onClick={onCreateTrayItem}
+              variant="outline-primary"
+              size="sm"
+            >
+              <i className="fa fa-plus"></i>
+            </Button>
           </div>
-          {notScheduledPlannables.map(plannable => {
-            const color = (plannable.pkg ? programmeGroups.find(it => it._id === plannable.pkg)?.color : null) ?? DEFAULT_PROGRAM_COLOR;
+          {notScheduledPlannables.map((plannable) => {
+            const color =
+              (plannable.pkg
+                ? programmeGroups.find((it) => it._id === plannable.pkg)?.color
+                : null) ?? DEFAULT_PROGRAM_COLOR;
             const isDark = color !== null ? isColorDark(color) : false;
             return (
               <div
                 key={plannable._id}
                 className={[
-                  'schedulePage__traySegment',
-                  isDark && 'schedulePage__traySegment--dark',
-                ].filter(Boolean).join(' ')}
-                style={{
-                  '--segment-color': color,
-                } as any}
-
+                  "schedulePage__traySegment",
+                  isDark && "schedulePage__traySegment--dark",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+                style={
+                  {
+                    "--segment-color": color,
+                  } as any
+                }
                 draggable={true}
                 onDragStart={(e) => {
-                  e.dataTransfer.setData(MIME_TYPE, plannable._id as string)
-                  e.dataTransfer.effectAllowed = "move"
-                  setDraggingPlannable({ id: plannable._id })
+                  e.dataTransfer.setData(MIME_TYPE, plannable._id as string);
+                  e.dataTransfer.effectAllowed = "move";
+                  setDraggingPlannable({ id: plannable._id });
                 }}
                 onClick={() => {
-                  setEditingTrayItem(plannable._id)
+                  setEditingTrayItem(plannable._id);
                 }}
               >
                 {plannable.title}
               </div>
             );
-          }
-          )}
+          })}
         </div>
       )}
 
       {contextMenu && contextMenuProgram && (
-        <div className="contextMenu__wrapper" onClick={() => {
-          setContextMenu(null)
-        }}>
+        <div
+          className="contextMenu__wrapper"
+          onClick={() => {
+            setContextMenu(null);
+          }}
+        >
           <div
             className="contextMenu"
-            style={{
-              '--position-x': `${contextMenu.x}px`,
-              '--position-y': `${contextMenu.y}px`,
-            } as any}
+            style={
+              {
+                "--position-x": `${contextMenu.x}px`,
+                "--position-y": `${contextMenu.y}px`,
+              } as any
+            }
           >
             {contextMenuProgram.locked ? (
               <>
-                <div className="contextMenu__item" onClick={() => {
-                  setContextMenu(null)
-                  updateProgram({ ...contextMenuProgram, locked: false });
-                }
-                }>
+                <div
+                  className="contextMenu__item"
+                  onClick={() => {
+                    setContextMenu(null);
+                    updateProgram({ ...contextMenuProgram, locked: false });
+                  }}
+                >
                   Odemknout
                 </div>
               </>
             ) : (
               <>
-                <div className="contextMenu__item" onClick={() => {
-                  setContextMenu(null)
-                  onCopy(contextMenu.id, 1)
-                }}>
+                <div
+                  className="contextMenu__item"
+                  onClick={() => {
+                    setContextMenu(null);
+                    onCopy(contextMenu.id, 1);
+                  }}
+                >
                   Opakovat další den
                 </div>
-                <div className="contextMenu__item" onClick={() => {
-                  setContextMenu(null)
-                  updateProgram({ ...contextMenuProgram, locked: true });
-                }}>
+                <div
+                  className="contextMenu__item"
+                  onClick={() => {
+                    setContextMenu(null);
+                    updateProgram({ ...contextMenuProgram, locked: true });
+                  }}
+                >
                   Zamknout
                 </div>
               </>
@@ -874,5 +1172,5 @@ export const ComposeSchedule = ({ editable, violations }: ComposeScheduleProps) 
         </div>
       )}
     </div>
-  )
-}
+  );
+};

--- a/src/helpers/isColorDark.ts
+++ b/src/helpers/isColorDark.ts
@@ -1,0 +1,12 @@
+export function isColorDark(color: string): boolean {
+	if (color.length !== 7 || !color.match(/^#[0-9a-f]{6}$/i)) {
+		console.error(`Invalid color: ${color}`);
+		return false;
+	}
+	const rgb = parseInt(color.replace('#', ''), 16);
+	const r = (rgb >> 16) & 0xff;
+	const g = (rgb >> 8) & 0xff;
+	const b = (rgb >> 0) & 0xff;
+	const a = 1 - (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+	return a > 0.5;
+}

--- a/src/helpers/isColorDark.ts
+++ b/src/helpers/isColorDark.ts
@@ -1,12 +1,12 @@
 export function isColorDark(color: string): boolean {
-	if (color.length !== 7 || !color.match(/^#[0-9a-f]{6}$/i)) {
-		console.error(`Invalid color: ${color}`);
-		return false;
-	}
-	const rgb = parseInt(color.replace('#', ''), 16);
-	const r = (rgb >> 16) & 0xff;
-	const g = (rgb >> 8) & 0xff;
-	const b = (rgb >> 0) & 0xff;
-	const a = 1 - (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-	return a > 0.5;
+  if (color.length !== 7 || !color.match(/^#[0-9a-f]{6}$/i)) {
+    console.error(`Invalid color: ${color}`);
+    return false;
+  }
+  const rgb = parseInt(color.replace("#", ""), 16);
+  const r = (rgb >> 16) & 0xff;
+  const g = (rgb >> 8) & 0xff;
+  const b = (rgb >> 0) & 0xff;
+  const a = 1 - (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return a > 0.5;
 }

--- a/src/helpers/timeCompare.ts
+++ b/src/helpers/timeCompare.ts
@@ -1,0 +1,13 @@
+import {Temporal} from "@js-temporal/polyfill";
+
+export function minTime(a: Temporal.PlainTime, ...b: Temporal.PlainTime[]): Temporal.PlainTime {
+	return b.reduce((acc, time) => {
+		return Temporal.PlainTime.compare(acc, time) < 0 ? acc : time
+	}, a)
+}
+
+export function maxTime(a: Temporal.PlainTime, ...b: Temporal.PlainTime[]): Temporal.PlainTime {
+	return b.reduce((acc, time) => {
+		return Temporal.PlainTime.compare(acc, time) > 0 ? acc : time
+	}, a)
+}

--- a/src/helpers/timeCompare.ts
+++ b/src/helpers/timeCompare.ts
@@ -1,13 +1,19 @@
-import {Temporal} from "@js-temporal/polyfill";
+import { Temporal } from "@js-temporal/polyfill";
 
-export function minTime(a: Temporal.PlainTime, ...b: Temporal.PlainTime[]): Temporal.PlainTime {
-	return b.reduce((acc, time) => {
-		return Temporal.PlainTime.compare(acc, time) < 0 ? acc : time
-	}, a)
+export function minTime(
+  a: Temporal.PlainTime,
+  ...b: Temporal.PlainTime[]
+): Temporal.PlainTime {
+  return b.reduce((acc, time) => {
+    return Temporal.PlainTime.compare(acc, time) < 0 ? acc : time;
+  }, a);
 }
 
-export function maxTime(a: Temporal.PlainTime, ...b: Temporal.PlainTime[]): Temporal.PlainTime {
-	return b.reduce((acc, time) => {
-		return Temporal.PlainTime.compare(acc, time) > 0 ? acc : time
-	}, a)
+export function maxTime(
+  a: Temporal.PlainTime,
+  ...b: Temporal.PlainTime[]
+): Temporal.PlainTime {
+  return b.reduce((acc, time) => {
+    return Temporal.PlainTime.compare(acc, time) > 0 ? acc : time;
+  }, a);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -391,3 +391,432 @@ p {
     display: none;
   }
 }
+
+.App:has(.schedulePage) {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.schedulePage {
+  display: flex;
+  background: white;
+  color: black;
+  height: 100%;
+  max-height: 100vh;
+  align-items: flex-start;
+  overflow: hidden;
+}
+
+.schedulePage__tray {
+  border-left: 3px solid #ccc;
+  width: 150px;
+  display: flex;
+  flex-direction: column;
+  padding: 0.5em;
+  height: 100%;
+}
+
+.schedulePage_trayHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1em;
+}
+
+.schedulePage_trayHeaderTitle {
+  margin: 0;
+  font-size: 1.3em;
+  line-height: 1;
+}
+
+.schedulePage__traySegment {
+  padding: .2em .4em;
+  margin: 0 0 1px 1px;
+  background: var(--segment-color, white);
+  border-radius: .5em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.schedulePage__traySegment--dark {
+  color: white;
+}
+
+.schedulePage__mainContent {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.schedulePage__tableSegment {
+  flex-grow: 1;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+.schedulePage__bottomControls {
+  border-top: 1px solid gray;
+  display: flex;
+  align-items: center;
+  /*justify-content: flex-end;*/
+  padding: 0.2em;
+}
+
+.schedulePage__bottomControls label {
+  display: flex;
+  align-items: center;
+}
+
+.schedulePage__bottomControlsLeft {
+  flex: 1 0 auto;
+  display: flex;
+  justify-content: flex-start;
+}
+
+
+.schedulePage__bottomControlsRight {
+  flex: 1 0 auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.scheduleTable {
+  display: grid;
+  grid-template-columns: 3em min-content auto;
+  grid-template-rows: auto;
+  grid-auto-rows: max(2em, 5em / var(--groups-count));
+  padding: 0 1em 1em;
+  width: calc(100% * var(--width-scale));
+}
+
+.scheduleTable__actions {
+  grid-row: 1 / span 1;
+  grid-column: 1 / span 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-right: 1em;
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  background: white;
+  margin-left: -1em;
+  padding-left: 1em;
+}
+
+.scheduleTable__dayLabel {
+  grid-row-start: calc(var(--day) * var(--groups-count) + 2);
+  grid-row-end: span var(--groups-count);
+  grid-column: 1;
+  padding: 1em 2em 1em 0;
+  margin-left: -1em;
+  white-space: nowrap;
+  align-self: center;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  transform-origin: center center;
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: white;
+}
+
+.scheduleTable__day {
+  grid-row-start: calc(var(--day) * var(--groups-count) + 2);
+  grid-row-end: span var(--groups-count);
+  grid-column: 3;
+  /*background: red;*/
+  /*z-index: 1;*/
+  /*pointer-events: all;*/
+}
+
+.scheduleTable__dayLine {
+  grid-row: calc((var(--day) + 1) * var(--groups-count) + 1);
+  grid-column: 1 / span 3;
+  border-bottom: 1px solid #ccc;
+}
+
+.scheduleTable__groupLabel {
+  grid-row: calc(var(--group-day) * var(--groups-count) + var(--group-index) + 2);
+  grid-column: 2;
+  white-space: nowrap;
+  align-self: stretch;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-right: .5em;
+  position: sticky;
+  left: 4em;
+  z-index: 1;
+  background: linear-gradient(90deg, white, white, transparent);
+}
+
+.scheduleTable__timeLabels {
+  grid-row: 1;
+  grid-column: 3;
+  position: sticky;
+  top: 0;
+  padding: 1em 0 2em;
+  /*background-color: #fffe;*/
+  height: 4em;
+  background: linear-gradient(to top, #fff0 0, #fffa 1em, #ffff 100%);
+  z-index: 1;
+}
+
+.scheduleTable__timeLabel {
+  grid-row: 1;
+  grid-column: 3;
+  align-self: end;
+  white-space: nowrap;
+  position: absolute;
+  left: calc(var(--time) * 100%);
+  transform-origin: left center;
+  bottom: 0;
+  transform: rotate(-90deg);
+  width: fit-content;
+}
+
+.scheduleTable__timeLine {
+  grid-row-start: 2;
+  grid-row-end: span calc(var(--groups-count) * var(--days-count));
+  grid-column: 3;
+  border-left: 1px solid #00000011;
+  position: relative;
+  left: calc(var(--time) * 100%);
+  width: 0;
+}
+
+.scheduleTable__timeLine--major {
+  border-color: #00000055;
+}
+
+.scheduleTable__plannable {
+  grid-row-start: calc(var(--segment-day) * var(--groups-count) + var(--segment-group-first) + 2);
+  grid-row-end: span var(--segment-groups-count);
+  grid-column: 3;
+  width: calc(var(--segment-duration) * 100% - 1px);
+  position: relative;
+  left: calc(var(--segment-start) * 100%);
+  margin: 0 0 1px 1px;
+  overflow: hidden;
+}
+
+.scheduleTable__plannable, .scheduleTable__plannableExpansion {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: .2em .3em;
+  justify-content: flex-start;
+  background: var(--segment-color, white);
+}
+
+.scheduleTable__plannable--start {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.scheduleTable__plannable--end {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.scheduleTable__plannable::after, .scheduleTable__plannableExpansion::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  opacity: 0;
+  transition: opacity 0.5s;
+  filter: brightness(0.5);
+  border: 2px solid var(--segment-color, white);
+}
+
+.scheduleTable__plannable--dragged {
+  opacity: .5;
+}
+
+.scheduleTable__plannable--hovering::after, .scheduleTable__plannableExpansion::after {
+  opacity: 1;
+}
+
+.scheduleTable__plannableTitle {
+  overflow: hidden;
+  max-height: 100%;
+  white-space: nowrap;
+  font-size: .7em;
+  flex: 0 0 auto;
+}
+
+.scheduleTable__plannableOwners {
+  overflow: hidden;
+  max-height: 100%;
+  white-space: nowrap;
+  font-size: .5em;
+  padding: .1em .5em;
+  background: #ccc7;
+  border-radius: 1em;
+  max-width: 100%;
+  margin-bottom: 2px;
+}
+
+.scheduleTable__plannableExpansion {
+  position: fixed;
+  left: var(--position-x);
+  bottom: calc(100vh - var(--position-y));
+  z-index: 1;
+  padding: .5em;
+  color: black;
+  background: white;
+  border-radius: 0.5em;
+  border-bottom-left-radius: 0;
+  box-shadow: 0 0.25em 0.5em 0 rgba(0, 0, 0, 0.6);
+}
+
+
+.scheduleTable__plannableExpansion .scheduleTable__plannableTitle {
+  font-size: 1rem;
+}
+.scheduleTable__plannableExpansion .scheduleTable__plannableOwners {
+  font-size: .7rem;
+}
+
+.scheduleTable__plannable--dark {
+  color: white;
+}
+
+.scheduleTable__plannable--notHighlighted {
+  opacity: .3;
+  filter: blur(1px);
+}
+
+.scheduleTable__plannable--violated {
+  background-image: repeating-linear-gradient(
+    135deg,
+    rgba(0, 0, 0, 0),
+    rgba(0, 0, 0, 0) 1.25rem,
+    rgba(66, 66, 66, 0.15) 1.25rem,
+    rgba(66, 66, 66, 0.15) 2.5rem
+    );
+}
+
+.dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.dialog__content {
+  max-height: calc(100vh - 2em);
+  background: white;
+  border-radius: 0.5em;
+  padding: 1em;
+  overflow: auto;
+  width: 600px;
+  max-width: calc(100vw - 2em);
+}
+
+.contextMenu__wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+}
+
+.contextMenu {
+  position: fixed;
+  top: var(--position-y);
+  left: var(--position-x);
+  background: white;
+  display: flex;
+  flex-direction: column;
+  min-width: 10em;
+  padding: .1em;
+  gap: .1em;
+  border-radius: .1em;
+  align-items: stretch;
+  border: 1px solid #aaa;
+}
+
+.contextMenu__item {
+  padding: 0.2em 0.5em;
+}
+
+.contextMenu__item:hover {
+  background: #eee;
+  cursor: pointer;
+}
+
+.fastInput__fullScreenWrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
+  background: #fffe;
+  font-size: 2rem;
+  align-items: stretch;
+  flex-direction: column;
+}
+
+.fastInput__fullScreenWrapperInner {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: min(90vw, 900px);
+  margin: 5vh auto 0;
+}
+
+.fastInput__input {
+  flex: 1;
+  font-size: 1em;
+  padding: .5em;
+  border-radius: 10px;
+  border: 1px solid #aaa;
+  font-family: inherit;
+  font-weight: 600;
+}
+
+.fastInput__input:focus {
+  outline: none;
+  border-color: #3da9eb;
+}
+
+.fastInput__completedValue {
+  font-size: .7em;
+  margin-bottom: .5em;
+  padding-bottom: .5em;
+  border-bottom: 1px solid #ccc;
+}
+
+.fastInput__title {
+  margin: 0 0 .2em;
+  font-size: 1.5em;
+  text-align: center;
+}
+
+.fastInput__closeHint {
+  text-align: center;
+  font-size: .6em;
+  margin: 0 0 1em;
+  color: #999;
+}

--- a/src/store/settingsApi.js
+++ b/src/store/settingsApi.js
@@ -3,13 +3,11 @@ import { firestoreClientFactory } from "../FirestoreClient";
 
 export const DEFAULT_TIME_STEP = 15 * 60 * 1000;
 export const DEFAULT_WIDTH = 100;
-export const DEFAULT_TIMETABLE_LAYOUT_VERSION = "v1";
 
 function addDefaults(data) {
   return {
     timeStep: DEFAULT_TIME_STEP,
     width: DEFAULT_WIDTH,
-    timetableLayoutVersion: DEFAULT_TIMETABLE_LAYOUT_VERSION,
     ...(data && data.settings ? data.settings : {}),
   };
 }

--- a/src/store/settingsApi.js
+++ b/src/store/settingsApi.js
@@ -3,11 +3,13 @@ import { firestoreClientFactory } from "../FirestoreClient";
 
 export const DEFAULT_TIME_STEP = 15 * 60 * 1000;
 export const DEFAULT_WIDTH = 100;
+export const DEFAULT_TIMETABLE_LAYOUT_VERSION = "v1";
 
 function addDefaults(data) {
   return {
     timeStep: DEFAULT_TIME_STEP,
     width: DEFAULT_WIDTH,
+    timetableLayoutVersion: DEFAULT_TIMETABLE_LAYOUT_VERSION,
     ...(data && data.settings ? data.settings : {}),
   };
 }

--- a/src/store/timetableApi.js
+++ b/src/store/timetableApi.js
@@ -2,7 +2,11 @@ import { createApi, fakeBaseQuery } from "@reduxjs/toolkit/query/react";
 import { firestoreClientFactory } from "../FirestoreClient";
 
 function addDefaults(data) {
-  return { title: null, ...data };
+  return {
+    title: null,
+    layoutVersion: "v1",
+    ...data,
+  };
 }
 
 export const timetableApi = createApi({
@@ -39,7 +43,19 @@ export const timetableApi = createApi({
       },
       invalidatesTags: ["timetable"],
     }),
+    updateLayoutVersion: builder.mutation({
+      async queryFn({ table, data }) {
+        const client = firestoreClientFactory.getClient(table);
+        await client.updateTimetable({ layoutVersion: data });
+        return { data: null };
+      },
+      invalidatesTags: ["timetable"],
+    }),
   }),
 });
 
-export const { useGetTimetableQuery, useUpdateTitleMutation } = timetableApi;
+export const {
+  useGetTimetableQuery,
+  useUpdateTitleMutation,
+  useUpdateLayoutVersionMutation,
+} = timetableApi;


### PR DESCRIPTION
The story is that few years ago I tried this tool (back when it was using mongoDB and tray wasn't there - which I apparently invented also independetly - just called it zásobník instead of odkladiště). I created my own tool, which is (at least in my eyes) better that this in some ways, but worse in others. The main difference being ease of use of the timetable. 

I have decided to retire my tool and contribute here. I did it as a opt-in option, since it's quite a big change. I have decided to use typescript, although it is not used in this project, because the source is written in TS and I saw at as the only option to manage to do it (since I am able to check the code for dumb mistakes easily). Sometimes the variables naming might be weird, it can be a leftover from my system (which used 3-levels of entities to represent a program). 

**Features of my implementation:** 
- Time guidelines (vertical lines).
- Zooming.
- Up to one-minute precision (depending on the zoom).
- Handles cases where we have to split a block across days or groups.

<details><summary>
<strong>Block splitting "bug"</strong>
</summary>
<p>

Following two images are showing the same program:

![image](https://github.com/user-attachments/assets/cac589d9-222d-4850-981b-2ef275b896a9)

![image](https://github.com/user-attachments/assets/159fa1fb-ec4c-4435-9656-742f014c07bb)

</p>
</details> 

<details><summary>
<strong>Video demo</strong>
</summary>
<p>

https://github.com/user-attachments/assets/b4c2b071-f5c6-4972-986c-fc906494a52f


</p>
</details> 

**Missing features:**
- Current time indicator 
- Filters on the top
- Printing 
- Program swap

**Commits:**
- Update README with local development setup instructions
- Add timetable layout version to settings
- Implement TimetableV2

ref #245, #77, #72