### PR TITLE
Move tray pinning to global state

### DIFF
--- a/src/components/Tray.jsx
+++ b/src/components/Tray.jsx
@@ -1,16 +1,16 @@
 import React from "react";
 import { useDrop } from "react-dnd";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { getProgramRects, sortTrayPrograms } from "../helpers/TrayUtils";
 import { useNavigate } from "react-router";
 import { level } from "../helpers/Level";
-import { useState } from "react";
 import { Block } from "./Blocks";
 import { getRect } from "../helpers/TimetableUtils";
 import Program from "./Program";
 import { useGetPackagesQuery } from "../store/packagesApi";
 import { DEFAULT_WIDTH, useGetSettingsQuery } from "../store/settingsApi";
 import { useGetProgramsQuery } from "../store/programsApi";
+import { togglePinTray } from "../store/viewSlice";
 
 export function Tray({ settings, onDroppableDrop }) {
   const { table } = useSelector((state) => state.auth);
@@ -51,7 +51,8 @@ export function Tray({ settings, onDroppableDrop }) {
     userLevel >= level.EDIT,
   );
 
-  const [pinned, setPinned] = useState(false);
+  const pinned = useSelector((state) => state.view.pinTray);
+  const dispatch = useDispatch();
 
   const navigate = useNavigate();
 
@@ -79,7 +80,7 @@ export function Tray({ settings, onDroppableDrop }) {
         </div>
         <button
           className={"btn" + (pinned ? " btn-dark" : "")}
-          onClick={() => setPinned(!pinned)}
+          onClick={() => dispatch(togglePinTray())}
           title="Připnout"
         >
           <i className="fa fa-thumb-tack" aria-hidden="true"></i>

--- a/src/store/viewSlice.js
+++ b/src/store/viewSlice.js
@@ -15,6 +15,7 @@ export const viewSlice = createSlice({
     activeRange: undefined,
     peopleEnabled: false,
     activePeople: [],
+    pinTray: false,
   },
   reducers: {
     toggleHighlighting(state) {
@@ -65,6 +66,9 @@ export const viewSlice = createSlice({
           1,
         );
     },
+    togglePinTray(state) {
+      state.pinTray = !state.pinTray;
+    },
   },
 });
 
@@ -81,6 +85,7 @@ export const {
   setActiveRange,
   togglePeopleEnabled,
   toggleActivePerson,
+  togglePinTray,
 } = viewSlice.actions;
 
 export default viewSlice.reducer;


### PR DESCRIPTION
To make it easier for layout changes in higher-level components.