### PR TITLE
Skip GCP remote build

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,8 @@
     "build": "vite build",
     "test": "vitest",
     "lint": "eslint --no-error-on-unmatched-pattern src/**/*.js src/**/*.jsx src/**/*.ts src/**/*.tsx cypress/**/*.js cypress/**/*.jsx",
-    "format": "prettier --check ."
+    "format": "prettier --check .",
+    "gcp-build": "true"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
The app is actually built in a github workflow and only static files are uploaded. We can save some time by not doing unnecessary remote build.