### PR TITLE
Fix app.yaml paths

### DIFF
--- a/client/app.yaml
+++ b/client/app.yaml
@@ -5,8 +5,8 @@ automatic_scaling:
   min_instances: 0
   max_idle_instances: 1
 handlers:
-  - url: /static
-    static_dir: dist/static
+  - url: /assets
+    static_dir: dist/assets
     redirect_http_response_code: 301
     secure: always
   - url: /(.*\..+)$


### PR DESCRIPTION
The handler was working anyway (using the second handler), but this way it is more explicit.