### PR TITLE
Fix eslint config

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -28,6 +28,9 @@ export default [
     },
   },
   {
+    ignores: ["node_modules/*", "dist/*"],
+  },
+  {
     plugins: {
       react,
       cypress,

--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
     "start": "vite",
     "build": "vite build",
     "test": "vitest",
-    "lint": "eslint --no-error-on-unmatched-pattern src/**/*.js src/**/*.jsx src/**/*.ts src/**/*.tsx cypress/**/*.js cypress/**/*.jsx",
+    "lint": "eslint --no-error-on-unmatched-pattern",
     "format": "prettier --check .",
     "gcp-build": "true"
   },


### PR DESCRIPTION
Remove hardcoded paths as suggested by @VojtaStanek in #887, but also add
ignores so that ESlint will not pick up stuff in node modules and dist.