### PR TITLE
Fix invalid middleware stacking in shift

### DIFF
--- a/shift/src/index.js
+++ b/shift/src/index.js
@@ -9,7 +9,7 @@ import { authMiddleware } from "@scout-planner/common/authMiddleware";
 
 http("shift-timetable", async (req, res) =>
   corsMiddleware(["POST"])(req, res, async () =>
-    authMiddleware(req, res, async (req, res) => shiftTimetable(req, res)),
+    authMiddleware(req, res, async () => shiftTimetable(req, res)),
   ),
 );
 


### PR DESCRIPTION
Variables req and res were shadowed - we want to pass the original objects, `next` should take no parameters.

ref #475 